### PR TITLE
feat: v0.0.11

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -23,4 +23,6 @@ jobs:
             feat
             fix
             chore
+            docs
+            bugfix
           requireScope: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include skill.json

--- a/README.md
+++ b/README.md
@@ -8,8 +8,27 @@ Available on PyPi: `pip install neon-homeassistant-skill`
 
 ## Installation on Neon
 
+\***\*Note\*\***: This skill and the required PHAL plugin come pre-installed on Neon images for the Mycroft Mark II and Neon's published Docker images. These instructions are for custom development builds or creating your own Neon instance from scratch.
+
 Install ovos-PHAL-plugin-homeassistant [per their documentation](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-homeassistant)
-Note that Neon uses a YAML configuration, not a JSON file, so edit `~/.config/neon/neon.yaml` and make the following update for a minimal installation:
+
+Then, you can `pip install neon-homeassistant-skill`, or handle the installation from the `~/.config/neon/neon.yaml` file if you prefer:
+
+```yaml
+skills:
+  default_skills:
+    # Jokes skill included because it cannot be pip installed to the image
+    - https://github.com/JarbasSkills/skill-icanhazdadjokes/tree/dev
+    - neon-homeassistant-skill # Optionally with a version, such as neon-homeassistant-skill==0.0.10
+```
+
+### Authenticating to Home Assistant
+
+On a device with a screen, such as the Mycroft Mark II, you can say `open home assistant dashboard` and use the OAuth login flow to authenticate from the PHAL plugin. If you don't have a screen available or prefer to edit the configuration directly, read on.
+
+---
+
+The documentation for ovos-PHAL-plugin-homeassistant specifies which configuration file to put your Home Assistant hostname/port and API key. Note that Neon uses a YAML configuration, not a JSON file, so edit `~/.config/neon/neon.yaml` and make the following update for a minimal installation:
 
 ```yaml
 PHAL:
@@ -18,15 +37,9 @@ PHAL:
     api_key: <HA_LONG_LIVED_TOKEN>
 ```
 
-(the `PHAL` node should be at the root of the user configuration file, appended to the end of file if existing content exists, and will merge with system configuration per [Neon Configuration Docs](https://neongeckocom.github.io/neon-docs/quick_reference/configuration/))
+The `PHAL` node above should be at the root of the Neon user configuration file, appended to the end of file if existing content exists, and will merge with system configuration per [Neon Configuration Docs.](https://neongeckocom.github.io/neon-docs/quick_reference/configuration/)
 
-You can also say `open home assistant dashboard` on a device with a screen, like the Mark II, and use the OAuth login flow from the PHAL plugin.
-
-SSH to the Neon device
-
-```shell
-osm install https://github.com/mikejgray/neon-homeassistant-skill
-```
+Mycroft Mark II does not always support .local hostnames such as the default `homeassistant.local` DNS. You may need to use the IP of your Home Assistant instance instead. If you have a Nabu Casa subscription and don't mind traffic going out to the internet using your public Nabu Casa DNS is also a supported option. However, if your internet connectivity drops from your Neon instance, you will be unable to control your smart home devices from Neon. A local DNS/IP is preferable.
 
 ## Upcoming Features
 

--- a/neon_homeassistant_skill/__init__.py
+++ b/neon_homeassistant_skill/__init__.py
@@ -5,7 +5,7 @@ from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.util.log import LOG
 from pfzy import fuzzy_match
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 
 # https://github.com/OpenVoiceOS/ovos-PHAL-plugin-homeassistant/blob/master/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -206,6 +206,15 @@ class NeonHomeAssistantSkill(MycroftSkill):
             self.speak_dialog("area.dashboard.opened", data={"area": area})
         else:
             self.speak_dialog("area.not.found")
+
+    @intent_handler("assist.intent")
+    def handle_assist_intent(self, message):
+        command = message.data.get("command")
+        if command:
+            self.bus.emit(Message("ovos.phal.plugin.homeassistant.assist.intent"), {"command": command})
+            self.speak_dialog("assist")
+        else:
+            self.speak_dialog("Sorry, I didn't catch what to tell Home Assistant.")
 
     # @intent_handler("vacuum.action.intent")  # TODO: Find an intent that doesn't conflict with OCP
     # def handle_vacuum_action_intent(self, message):

--- a/neon_homeassistant_skill/__init__.py
+++ b/neon_homeassistant_skill/__init__.py
@@ -202,7 +202,7 @@ class NeonHomeAssistantSkill(MycroftSkill):
     def handle_show_area_dashboard_intent(self, message):
         area = message.data.get("area")
         if area:
-            self.bus.emit(Message("ovos.phal.plugin.homeassistant.show.area.dashboard"), {"area": area})
+            self.bus.emit(Message("ovos.phal.plugin.homeassistant.show.area.dashboard", {"area": area}))
             self.speak_dialog("area.dashboard.opened", data={"area": area})
         else:
             self.speak_dialog("area.not.found")
@@ -211,7 +211,7 @@ class NeonHomeAssistantSkill(MycroftSkill):
     def handle_assist_intent(self, message):
         command = message.data.get("command")
         if command:
-            self.bus.emit(Message("ovos.phal.plugin.homeassistant.assist.intent"), {"command": command})
+            self.bus.emit(Message("ovos.phal.plugin.homeassistant.assist.intent", {"command": command}))
             self.speak_dialog("assist")
         else:
             self.speak_dialog("Sorry, I didn't catch what to tell Home Assistant.")

--- a/neon_homeassistant_skill/__init__.py
+++ b/neon_homeassistant_skill/__init__.py
@@ -1,11 +1,17 @@
 import asyncio
-
+from typing import List
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.util.log import LOG
 from pfzy import fuzzy_match
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"
+
+
+def chunks(lst, n) -> List[list]:
+    """Split list into n-length chunks."""
+    n = max(1, n)
+    return [lst[i : i + n] for i in range(0, len(lst), n)]
 
 
 # https://github.com/OpenVoiceOS/ovos-PHAL-plugin-homeassistant/blob/master/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -14,8 +20,9 @@ class NeonHomeAssistantSkill(MycroftSkill):
 
     def __init__(self):
         super(NeonHomeAssistantSkill, self).__init__(name="NeonHomeAssistantSkill")
-        self.devices_list = None
+        self.devices_list = []
         self.skill_id = "neon-homeassistant-skill"
+        self.device_list_pagination = 10
 
     def initialize(self):
         self._build_device_list()
@@ -29,9 +36,31 @@ class NeonHomeAssistantSkill(MycroftSkill):
 
     def _handle_device_list(self, message):
         self.devices_list = message.data
+        self.log.info(type(self.devices_list))
+        self.log.info(self.devices_list)
 
     def _handle_device_state_update(self, _):
         self._build_device_list()
+
+    @intent_handler("list.devices.intent")
+    def handle_list_devices(self, _):
+        """Handle intent to read all devices out loud."""
+        for chunk in chunks(self.devices_list, self.device_list_pagination)[0]:
+            spoken_chunk = ",".join([c.get("name", "") for c in chunk])
+            self.speak(spoken_chunk)
+            # TODO: Make it conversational, so you can stop or even skip ahead if needed
+
+    @intent_handler("list.device.types.intent")
+    def handle_list_device_types(self, message):
+        """Handle intent to read all devices of a certain type out loud."""
+        dev_type = message.get("device_type")
+        device_list_by_type = [dev for dev in self.devices_list if dev.get("type") == dev_type]
+        if len(device_list_by_type) == 0:
+            self.speak(f"I'm sorry, Home Assistant didn't tell me about any devices of the {dev_type} type.")
+        for chunk in chunks(device_list_by_type, self.device_list_pagination)[0]:
+            spoken_chunk = ",".join([c.get("name", "") for c in chunk])
+            self.speak(spoken_chunk)
+            # TODO: Make it conversational, so you can stop or even skip ahead if needed
 
     @intent_handler("sensor.intent")
     def get_device_intent(self, message):
@@ -64,7 +93,7 @@ class NeonHomeAssistantSkill(MycroftSkill):
             self.speak_dialog("device.not.found", data={"device": device})
 
     @intent_handler("turn.off.intent")
-    @intent_handler("stop.intent")
+    @intent_handler("stop.intent")  # Consider changing this so it stops reading from the list of devices
     def handle_turn_off_intent(self, message) -> None:
         """Handle turn off intent."""
         LOG.info(message.data)

--- a/neon_homeassistant_skill/dialog/en-us/assist.dialog
+++ b/neon_homeassistant_skill/dialog/en-us/assist.dialog
@@ -1,0 +1,3 @@
+I told Home Assistant.
+I let Home Assistant know.
+I get jealous when you talk to other voice assistants, but I did it anyway.

--- a/neon_homeassistant_skill/vocab/en-us/assist.intent
+++ b/neon_homeassistant_skill/vocab/en-us/assist.intent
@@ -1,0 +1,1 @@
+tell home assistant (|to){command}

--- a/neon_homeassistant_skill/vocab/en-us/lights.set.brightness.intent
+++ b/neon_homeassistant_skill/vocab/en-us/lights.set.brightness.intent
@@ -1,3 +1,2 @@
 (set|change) (|the) brightness of (|the|my) {entity} to {brightness} (|percent)
 set (|the|my) {entity} brightness to {brightness} (|percent)
-set (|the|my) {entity} to {brightness} (|percent)

--- a/neon_homeassistant_skill/vocab/en-us/lights.set.color.intent
+++ b/neon_homeassistant_skill/vocab/en-us/lights.set.color.intent
@@ -1,2 +1,2 @@
-(set|make) (|the|my) {entity} color (to |){color}
-(set|make) (|the|my) light {entity} to {color}
+(adjust|change|make) (|the|my) {entity} color (to |){color}
+(adjust|change|make) (|the|my) light {entity} to {color}

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,37 +71,38 @@ tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy
 
 [[package]]
 name = "bandit"
-version = "1.7.4"
+version = "1.7.5"
 description = "Security oriented static analyser for python code."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "bandit-1.7.4-py3-none-any.whl", hash = "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"},
-    {file = "bandit-1.7.4.tar.gz", hash = "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2"},
+    {file = "bandit-1.7.5-py3-none-any.whl", hash = "sha256:75665181dc1e0096369112541a056c59d1c5f66f9bb74a8d686c3c362b83f549"},
+    {file = "bandit-1.7.5.tar.gz", hash = "sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
 GitPython = ">=1.0.1"
 PyYAML = ">=5.3.1"
+rich = "*"
 stevedore = ">=1.20.0"
 
 [package.extras]
-test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml"]
-toml = ["toml"]
+test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "tomli (>=1.1.0)"]
+toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.11.2"
+version = "4.12.2"
 description = "Screen-scraping library"
 category = "dev"
 optional = false
 python-versions = ">=3.6.0"
 files = [
-    {file = "beautifulsoup4-4.11.2-py3-none-any.whl", hash = "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39"},
-    {file = "beautifulsoup4-4.11.2.tar.gz", hash = "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"},
+    {file = "beautifulsoup4-4.12.2-py3-none-any.whl", hash = "sha256:bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a"},
+    {file = "beautifulsoup4-4.12.2.tar.gz", hash = "sha256:492bbc69dca35d12daac71c4db1bfff0c876c00ef4a2ffacce226d4638eb72da"},
 ]
 
 [package.dependencies]
@@ -113,32 +114,46 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "22.12.0"
+version = "23.3.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
+    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
+    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
+    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
+    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
+    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
+    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
+    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
+    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
+    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
+    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
+    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
+    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
+    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
 ]
 
 [package.dependencies]
 click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
@@ -193,100 +208,87 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.0.1"
+version = "3.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.0.1.tar.gz", hash = "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-win32.whl", hash = "sha256:502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b"},
-    {file = "charset_normalizer-3.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-win32.whl", hash = "sha256:71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3"},
-    {file = "charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-win32.whl", hash = "sha256:95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41"},
-    {file = "charset_normalizer-3.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-win32.whl", hash = "sha256:0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154"},
-    {file = "charset_normalizer-3.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-win32.whl", hash = "sha256:4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e"},
-    {file = "charset_normalizer-3.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-win32.whl", hash = "sha256:39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8"},
-    {file = "charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59"},
-    {file = "charset_normalizer-3.0.1-py3-none-any.whl", hash = "sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24"},
+    {file = "charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-win32.whl", hash = "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-win32.whl", hash = "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-win32.whl", hash = "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-win32.whl", hash = "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-win32.whl", hash = "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b"},
+    {file = "charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d"},
 ]
 
 [[package]]
@@ -333,13 +335,13 @@ files = [
 
 [[package]]
 name = "combo-lock"
-version = "0.2.4"
+version = "0.2.5"
 description = "A combined process and thread lock"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "combo_lock-0.2.4.tar.gz", hash = "sha256:85cfb74495ada54c13073dc2803132e16fa4b6158f76de3cbd965af8bfb9032f"},
+    {file = "combo_lock-0.2.5.tar.gz", hash = "sha256:fd72d49146280ab612679a59b333b68c0b010253e2bf8fdbabda9cb790d60ec8"},
 ]
 
 [package.dependencies]
@@ -348,14 +350,14 @@ memory-tempfile = "*"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.0"
+version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
-    {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
 ]
 
 [package.extras]
@@ -363,19 +365,19 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.9.0"
+version = "3.11.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
-    {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
+    {file = "filelock-3.11.0-py3-none-any.whl", hash = "sha256:f08a52314748335c6460fc8fe40cd5638b85001225db78c2aa01c8c0db83b318"},
+    {file = "filelock-3.11.0.tar.gz", hash = "sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37"},
 ]
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "diff-cover (>=7.5)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -411,14 +413,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.30"
-description = "GitPython is a python library used to interact with Git repositories"
+version = "3.1.31"
+description = "GitPython is a Python library used to interact with Git repositories"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"},
-    {file = "GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8"},
+    {file = "GitPython-3.1.31-py3-none-any.whl", hash = "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"},
+    {file = "GitPython-3.1.31.tar.gz", hash = "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573"},
 ]
 
 [package.dependencies]
@@ -472,19 +474,19 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.11.5"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
+    {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
 ]
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -576,6 +578,32 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "2.2.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
+    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "mccabe"
 version = "0.4.0"
 description = "McCabe checker, plugin for flake8"
@@ -585,6 +613,18 @@ python-versions = "*"
 files = [
     {file = "mccabe-0.4.0-py2.py3-none-any.whl", hash = "sha256:cbc2938f6c01061bc6d21d0c838c2489664755cb18676f0734d7617f4577d09e"},
     {file = "mccabe-0.4.0.tar.gz", hash = "sha256:9a2b12ebd876e77c72e41ebf401cc2e7c5b566649d50105ca49822688642207b"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -617,46 +657,42 @@ websocket-client = ">=0.54.0"
 
 [[package]]
 name = "mypy"
-version = "0.991"
+version = "1.2.0"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d"},
-    {file = "mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6"},
-    {file = "mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb"},
-    {file = "mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305"},
-    {file = "mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f"},
-    {file = "mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33"},
-    {file = "mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05"},
-    {file = "mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad"},
-    {file = "mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297"},
-    {file = "mypy-0.991-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813"},
-    {file = "mypy-0.991-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711"},
-    {file = "mypy-0.991-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd"},
-    {file = "mypy-0.991-cp37-cp37m-win_amd64.whl", hash = "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93"},
-    {file = "mypy-0.991-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf"},
-    {file = "mypy-0.991-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135"},
-    {file = "mypy-0.991-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70"},
-    {file = "mypy-0.991-cp38-cp38-win_amd64.whl", hash = "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5"},
-    {file = "mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3"},
-    {file = "mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648"},
-    {file = "mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476"},
-    {file = "mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461"},
-    {file = "mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb"},
-    {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
+    {file = "mypy-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:701189408b460a2ff42b984e6bd45c3f41f0ac9f5f58b8873bbedc511900086d"},
+    {file = "mypy-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fe91be1c51c90e2afe6827601ca14353bbf3953f343c2129fa1e247d55fd95ba"},
+    {file = "mypy-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d26b513225ffd3eacece727f4387bdce6469192ef029ca9dd469940158bc89e"},
+    {file = "mypy-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3a2d219775a120581a0ae8ca392b31f238d452729adbcb6892fa89688cb8306a"},
+    {file = "mypy-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:2e93a8a553e0394b26c4ca683923b85a69f7ccdc0139e6acd1354cc884fe0128"},
+    {file = "mypy-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3efde4af6f2d3ccf58ae825495dbb8d74abd6d176ee686ce2ab19bd025273f41"},
+    {file = "mypy-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:695c45cea7e8abb6f088a34a6034b1d273122e5530aeebb9c09626cea6dca4cb"},
+    {file = "mypy-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0e9464a0af6715852267bf29c9553e4555b61f5904a4fc538547a4d67617937"},
+    {file = "mypy-1.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8293a216e902ac12779eb7a08f2bc39ec6c878d7c6025aa59464e0c4c16f7eb9"},
+    {file = "mypy-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:f46af8d162f3d470d8ffc997aaf7a269996d205f9d746124a179d3abe05ac602"},
+    {file = "mypy-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:031fc69c9a7e12bcc5660b74122ed84b3f1c505e762cc4296884096c6d8ee140"},
+    {file = "mypy-1.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:390bc685ec209ada4e9d35068ac6988c60160b2b703072d2850457b62499e336"},
+    {file = "mypy-1.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4b41412df69ec06ab141808d12e0bf2823717b1c363bd77b4c0820feaa37249e"},
+    {file = "mypy-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4e4a682b3f2489d218751981639cffc4e281d548f9d517addfd5a2917ac78119"},
+    {file = "mypy-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a197ad3a774f8e74f21e428f0de7f60ad26a8d23437b69638aac2764d1e06a6a"},
+    {file = "mypy-1.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c9a084bce1061e55cdc0493a2ad890375af359c766b8ac311ac8120d3a472950"},
+    {file = "mypy-1.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaeaa0888b7f3ccb7bcd40b50497ca30923dba14f385bde4af78fac713d6d6f6"},
+    {file = "mypy-1.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bea55fc25b96c53affab852ad94bf111a3083bc1d8b0c76a61dd101d8a388cf5"},
+    {file = "mypy-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:4c8d8c6b80aa4a1689f2a179d31d86ae1367ea4a12855cc13aa3ba24bb36b2d8"},
+    {file = "mypy-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:70894c5345bea98321a2fe84df35f43ee7bb0feec117a71420c60459fc3e1eed"},
+    {file = "mypy-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4a99fe1768925e4a139aace8f3fb66db3576ee1c30b9c0f70f744ead7e329c9f"},
+    {file = "mypy-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023fe9e618182ca6317ae89833ba422c411469156b690fde6a315ad10695a521"},
+    {file = "mypy-1.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d19f1a239d59f10fdc31263d48b7937c585810288376671eaf75380b074f238"},
+    {file = "mypy-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:2de7babe398cb7a85ac7f1fd5c42f396c215ab3eff731b4d761d68d0f6a80f48"},
+    {file = "mypy-1.2.0-py3-none-any.whl", hash = "sha256:d8e9187bfcd5ffedbe87403195e1fc340189a68463903c39e2b63307c9fa0394"},
+    {file = "mypy-1.2.0.tar.gz", hash = "sha256:f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1"},
 ]
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3"
+mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
@@ -669,26 +705,26 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
 name = "ovos-backend-client"
-version = "0.0.5"
+version = "0.0.6"
 description = "api client for supported ovos-core backends"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "ovos-backend-client-0.0.5.tar.gz", hash = "sha256:16a69f00fad4557d926e22aa40bc36b84c5109b6383265bb3dd08f7f0d05894f"},
-    {file = "ovos_backend_client-0.0.5-py3-none-any.whl", hash = "sha256:dcb183f042ae43406ba5b86c8e39447b6518130ec8f4e2056d7648245d37da2d"},
+    {file = "ovos-backend-client-0.0.6.tar.gz", hash = "sha256:a00f1deb90ecf5eda55dbc23717f0ac2555a0ac77c739a3cda3e6c86addfec72"},
+    {file = "ovos_backend_client-0.0.6-py3-none-any.whl", hash = "sha256:c5c1f8c629945106c6e5af73d18cc0f3d48ab4c6f7e430e6f238c6eaa96acdc6"},
 ]
 
 [package.dependencies]
@@ -700,13 +736,13 @@ offline = ["SpeechRecognition (>=3.8,<4.0)", "ovos-plugin-manager", "timezonefin
 
 [[package]]
 name = "ovos-config"
-version = "0.0.5"
+version = "0.0.7"
 description = "mycroft-core configuration module"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "ovos_config-0.0.5-py3-none-any.whl", hash = "sha256:20d6c01212ccd25229d6d3ef6b86b7d10687e81feff31303c97f3fd6db53e242"},
+    {file = "ovos_config-0.0.7-py3-none-any.whl", hash = "sha256:098a37b7375d3ba4dceaa85b839e0d9aa03597ba5704f8c22879c730e16b80ef"},
 ]
 
 [package.dependencies]
@@ -716,6 +752,7 @@ ovos-backend-client = ">=0.0.5,<1.0"
 ovos-utils = ">=0.0.23,<1.0"
 python-dateutil = ">=2.6,<3.0"
 PyYAML = ">=5.4,<6.0"
+rich-click = "*"
 watchdog = "*"
 
 [[package]]
@@ -772,20 +809,20 @@ rapidfuzz = "*"
 
 [[package]]
 name = "ovos-plugin-manager"
-version = "0.0.20"
+version = "0.0.22"
 description = "OpenVoiceOS plugin manager"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "ovos_plugin_manager-0.0.20-py3-none-any.whl", hash = "sha256:3520edf30976e1c67b9e1daf8330c8997b08c3e6a6b4b0d8910c618002627cee"},
+    {file = "ovos_plugin_manager-0.0.22-py3-none-any.whl", hash = "sha256:f006b52e99c8a77de3d32e363e532ebfec6d3b8ca885b1d604dc5ae2b1252771"},
 ]
 
 [package.dependencies]
 combo-lock = ">=0.2,<1.0"
 langcodes = ">=3.3.0,<3.4.0"
 ovos-config = ">=0.0.3,<1.0"
-ovos-utils = ">=0.0.23,<1.0"
+ovos-utils = ">=0.0.28,<1.0"
 quebra-frases = "*"
 requests = ">=2.26,<3.0"
 
@@ -831,21 +868,21 @@ requests-cache = "*"
 
 [[package]]
 name = "ovos-utils"
-version = "0.0.27"
+version = "0.0.30"
 description = "collection of simple utilities for use across the mycroft ecosystem"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "ovos_utils-0.0.27-py3-none-any.whl", hash = "sha256:168d3462dfc7a42e5bfbe3e4a43dc793556d95d6974028148667b3e6de7c0846"},
-    {file = "ovos_utils-0.0.27.tar.gz", hash = "sha256:a116189e30efd15f8dbc5e53efafc3ce1051b30eb7c07393db43b75b3ae9eba9"},
+    {file = "ovos_utils-0.0.30-py3-none-any.whl", hash = "sha256:904ea84bdebe71c57fef30c8aa0bd6980f96d9fc8667aac01438ec547074da41"},
+    {file = "ovos_utils-0.0.30.tar.gz", hash = "sha256:a2a68f4856c5addf551d0591f32186d3abb4fe4c9f61dd8f83e34d6c137d5e20"},
 ]
 
 [package.dependencies]
 json-database = ">=0.7,<1.0"
 kthread = ">=0.2,<1.0"
 mycroft-messagebus-client = ">=0.9,<0.9.2 || >0.9.2,<0.9.3 || >0.9.3,<1.0"
-ovos-config = ">=0.0.3,<1.0"
+ovos-config = ">=0.0.7,<1.0"
 pexpect = ">=4.8,<5.0"
 requests = ">=2.26,<3.0"
 watchdog = "*"
@@ -915,14 +952,14 @@ appdirs = "*"
 
 [[package]]
 name = "pathspec"
-version = "0.10.3"
+version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
-    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
 ]
 
 [[package]]
@@ -981,22 +1018,22 @@ docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.2.0-py3-none-any.whl", hash = "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"},
+    {file = "platformdirs-3.2.0.tar.gz", hash = "sha256:d5b638ca397f25f979350ff789db335903d7ea010ab28903f57b27e1b16c2b08"},
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
+typing-extensions = {version = ">=4.5", markers = "python_version < \"3.8\""}
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -1085,6 +1122,21 @@ files = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.14.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
+    {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
+]
+
+[package.extras]
+plugins = ["importlib-metadata"]
+
+[[package]]
 name = "pylint"
 version = "2.3.0"
 description = "python code static checker"
@@ -1104,18 +1156,17 @@ mccabe = "*"
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "7.3.0"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
-    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
+    {file = "pytest-7.3.0-py3-none-any.whl", hash = "sha256:933051fa1bfbd38a21e73c3960cebdad4cf59483ddba7696c48509727e17f201"},
+    {file = "pytest-7.3.0.tar.gz", hash = "sha256:58ecc27ebf0ea643ebfdf7fb1249335da761a00c9f955bcd922349bcb68ee57d"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -1125,7 +1176,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1194,101 +1245,101 @@ files = [
 
 [[package]]
 name = "rapidfuzz"
-version = "2.13.7"
+version = "2.15.0"
 description = "rapid fuzzy string matching"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "rapidfuzz-2.13.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b75dd0928ce8e216f88660ab3d5c5ffe990f4dd682fd1709dba29d5dafdde6de"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:24d3fea10680d085fd0a4d76e581bfb2b1074e66e78fd5964d4559e1fcd2a2d4"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8109e0324d21993d5b2d111742bf5958f3516bf8c59f297c5d1cc25a2342eb66"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5f705652360d520c2de52bee11100c92f59b3e3daca308ebb150cbc58aecdad"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7496e8779905b02abc0ab4ba2a848e802ab99a6e20756ffc967a0de4900bd3da"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24eb6b843492bdc63c79ee4b2f104059b7a2201fef17f25177f585d3be03405a"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:467c1505362823a5af12b10234cb1c4771ccf124c00e3fc9a43696512bd52293"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53dcae85956853b787c27c1cb06f18bb450e22cf57a4ad3444cf03b8ff31724a"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:46b9b8aa09998bc48dd800854e8d9b74bc534d7922c1d6e1bbf783e7fa6ac29c"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1fbad8fb28d98980f5bff33c7842efef0315d42f0cd59082108482a7e6b61410"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:43fb8cb030f888c3f076d40d428ed5eb4331f5dd6cf1796cfa39c67bf0f0fc1e"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:b6bad92de071cbffa2acd4239c1779f66851b60ffbbda0e4f4e8a2e9b17e7eef"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d00df2e4a81ffa56a6b1ec4d2bc29afdcb7f565e0b8cd3092fece2290c4c7a79"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-win32.whl", hash = "sha256:2c836f0f2d33d4614c3fbaf9a1eb5407c0fe23f8876f47fd15b90f78daa64c34"},
-    {file = "rapidfuzz-2.13.7-cp310-cp310-win_amd64.whl", hash = "sha256:c36fd260084bb636b9400bb92016c6bd81fd80e59ed47f2466f85eda1fc9f782"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b34e8c0e492949ecdd5da46a1cfc856a342e2f0389b379b1a45a3cdcd3176a6e"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:875d51b3497439a72e2d76183e1cb5468f3f979ab2ddfc1d1f7dde3b1ecfb42f"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ae33a72336059213996fe4baca4e0e4860913905c2efb7c991eab33b95a98a0a"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5585189b3d90d81ccd62d4f18530d5ac8972021f0aaaa1ffc6af387ff1dce75"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42085d4b154a8232767de8296ac39c8af5bccee6b823b0507de35f51c9cbc2d7"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:585206112c294e335d84de5d5f179c0f932837752d7420e3de21db7fdc476278"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f891b98f8bc6c9d521785816085e9657212621e93f223917fb8e32f318b2957e"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08590905a95ccfa43f4df353dcc5d28c15d70664299c64abcad8721d89adce4f"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b5dd713a1734574c2850c566ac4286594bacbc2d60b9170b795bee4b68656625"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:988f8f6abfba7ee79449f8b50687c174733b079521c3cc121d65ad2d38831846"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b3210869161a864f3831635bb13d24f4708c0aa7208ef5baac1ac4d46e9b4208"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:f6fe570e20e293eb50491ae14ddeef71a6a7e5f59d7e791393ffa99b13f1f8c2"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6120f2995f5154057454c5de99d86b4ef3b38397899b5da1265467e8980b2f60"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-win32.whl", hash = "sha256:b20141fa6cee041917801de0bab503447196d372d4c7ee9a03721b0a8edf5337"},
-    {file = "rapidfuzz-2.13.7-cp311-cp311-win_amd64.whl", hash = "sha256:ec55a81ac2b0f41b8d6fb29aad16e55417036c7563bad5568686931aa4ff08f7"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7d005e058d86f2a968a8d28ca6f2052fab1f124a39035aa0523261d6baf21e1f"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe59a0c21a032024edb0c8e43f5dee5623fef0b65a1e3c1281836d9ce199af3b"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfc04f7647c29fb48da7a04082c34cdb16f878d3c6d098d62d5715c0ad3000c"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:68a89bb06d5a331511961f4d3fa7606f8e21237467ba9997cae6f67a1c2c2b9e"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:effe182767d102cb65dfbbf74192237dbd22d4191928d59415aa7d7c861d8c88"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25b4cedf2aa19fb7212894ce5f5219010cce611b60350e9a0a4d492122e7b351"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3a9bd02e1679c0fd2ecf69b72d0652dbe2a9844eaf04a36ddf4adfbd70010e95"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5e2b3d020219baa75f82a4e24b7c8adcb598c62f0e54e763c39361a9e5bad510"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:cf62dacb3f9234f3fddd74e178e6d25c68f2067fde765f1d95f87b1381248f58"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:fa263135b892686e11d5b84f6a1892523123a00b7e5882eff4fbdabb38667347"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:fa4c598ed77f74ec973247ca776341200b0f93ec3883e34c222907ce72cb92a4"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-win32.whl", hash = "sha256:c2523f8180ebd9796c18d809e9a19075a1060b1a170fde3799e83db940c1b6d5"},
-    {file = "rapidfuzz-2.13.7-cp37-cp37m-win_amd64.whl", hash = "sha256:5ada0a14c67452358c1ee52ad14b80517a87b944897aaec3e875279371a9cb96"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ca8a23097c1f50e0fdb4de9e427537ca122a18df2eead06ed39c3a0bef6d9d3a"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9be02162af0376d64b840f2fc8ee3366794fc149f1e06d095a6a1d42447d97c5"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:af4f7c3c904ca709493eb66ca9080b44190c38e9ecb3b48b96d38825d5672559"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f50d1227e6e2a0e3ae1fb1c9a2e1c59577d3051af72c7cab2bcc430cb5e18da"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c71d9d512b76f05fa00282227c2ae884abb60e09f08b5ca3132b7e7431ac7f0d"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b52ac2626945cd21a2487aeefed794c14ee31514c8ae69b7599170418211e6f6"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca00fafd2756bc9649bf80f1cf72c647dce38635f0695d7ce804bc0f759aa756"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d248a109699ce9992304e79c1f8735c82cc4c1386cd8e27027329c0549f248a2"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c88adbcb933f6b8612f6c593384bf824e562bb35fc8a0f55fac690ab5b3486e5"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:c8601a66fbfc0052bb7860d2eacd303fcde3c14e87fdde409eceff516d659e77"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:27be9c63215d302ede7d654142a2e21f0d34ea6acba512a4ae4cfd52bbaa5b59"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3dcffe1f3cbda0dc32133a2ae2255526561ca594f15f9644384549037b355245"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8450d15f7765482e86ef9be2ad1a05683cd826f59ad236ef7b9fb606464a56aa"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-win32.whl", hash = "sha256:460853983ab88f873173e27cc601c5276d469388e6ad6e08c4fd57b2a86f1064"},
-    {file = "rapidfuzz-2.13.7-cp38-cp38-win_amd64.whl", hash = "sha256:424f82c35dbe4f83bdc3b490d7d696a1dc6423b3d911460f5493b7ffae999fd2"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c3fbe449d869ea4d0909fc9d862007fb39a584fb0b73349a6aab336f0d90eaed"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:16080c05a63d6042643ae9b6cfec1aefd3e61cef53d0abe0df3069b9d4b72077"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dbcf5371ea704759fcce772c66a07647751d1f5dbdec7818331c9b31ae996c77"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:114810491efb25464016fd554fdf1e20d390309cecef62587494fc474d4b926f"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99a84ab9ac9a823e7e93b4414f86344052a5f3e23b23aa365cda01393ad895bd"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81642a24798851b118f82884205fc1bd9ff70b655c04018c467824b6ecc1fabc"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3741cb0bf9794783028e8b0cf23dab917fa5e37a6093b94c4c2f805f8e36b9f"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:759a3361711586a29bc753d3d1bdb862983bd9b9f37fbd7f6216c24f7c972554"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1333fb3d603d6b1040e365dca4892ba72c7e896df77a54eae27dc07db90906e3"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:916bc2e6cf492c77ad6deb7bcd088f0ce9c607aaeabc543edeb703e1fbc43e31"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:23524635840500ce6f4d25005c9529a97621689c85d2f727c52eed1782839a6a"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:ebe303cd9839af69dd1f7942acaa80b1ba90bacef2e7ded9347fbed4f1654672"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:fe56659ccadbee97908132135de4b875543353351e0c92e736b7c57aee298b5a"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-win32.whl", hash = "sha256:3f11a7eff7bc6301cd6a5d43f309e22a815af07e1f08eeb2182892fca04c86cb"},
-    {file = "rapidfuzz-2.13.7-cp39-cp39-win_amd64.whl", hash = "sha256:e8914dad106dacb0775718e54bf15e528055c4e92fb2677842996f2d52da5069"},
-    {file = "rapidfuzz-2.13.7-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f7930adf84301797c3f09c94b9c5a9ed90a9e8b8ed19b41d2384937e0f9f5bd"},
-    {file = "rapidfuzz-2.13.7-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c31022d9970177f6affc6d5dd757ed22e44a10890212032fabab903fdee3bfe7"},
-    {file = "rapidfuzz-2.13.7-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f42b82f268689f429def9ecfb86fa65ceea0eaf3fed408b570fe113311bf5ce7"},
-    {file = "rapidfuzz-2.13.7-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b477b43ced896301665183a5e0faec0f5aea2373005648da8bdcb3c4b73f280"},
-    {file = "rapidfuzz-2.13.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d63def9bbc6b35aef4d76dc740301a4185867e8870cbb8719ec9de672212fca8"},
-    {file = "rapidfuzz-2.13.7-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c66546e30addb04a16cd864f10f5821272a1bfe6462ee5605613b4f1cb6f7b48"},
-    {file = "rapidfuzz-2.13.7-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f799d1d6c33d81e983d3682571cc7d993ae7ff772c19b3aabb767039c33f6d1e"},
-    {file = "rapidfuzz-2.13.7-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d82f20c0060ffdaadaf642b88ab0aa52365b56dffae812e188e5bdb998043588"},
-    {file = "rapidfuzz-2.13.7-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:042644133244bfa7b20de635d500eb9f46af7097f3d90b1724f94866f17cb55e"},
-    {file = "rapidfuzz-2.13.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:75c45dcd595f8178412367e302fd022860ea025dc4a78b197b35428081ed33d5"},
-    {file = "rapidfuzz-2.13.7-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3d8b081988d0a49c486e4e845a547565fee7c6e7ad8be57ff29c3d7c14c6894c"},
-    {file = "rapidfuzz-2.13.7-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16ffad751f43ab61001187b3fb4a9447ec2d1aedeff7c5bac86d3b95f9980cc3"},
-    {file = "rapidfuzz-2.13.7-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:020858dd89b60ce38811cd6e37875c4c3c8d7fcd8bc20a0ad2ed1f464b34dc4e"},
-    {file = "rapidfuzz-2.13.7-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cda1e2f66bb4ba7261a0f4c2d052d5d909798fca557cbff68f8a79a87d66a18f"},
-    {file = "rapidfuzz-2.13.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:b6389c50d8d214c9cd11a77f6d501529cb23279a9c9cafe519a3a4b503b5f72a"},
-    {file = "rapidfuzz-2.13.7.tar.gz", hash = "sha256:8d3e252d4127c79b4d7c2ae47271636cbaca905c8bb46d80c7930ab906cf4b5c"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3a610c7c1711a382b330c0e0910c981dd1cd398b135bc2e29219e685685d7afd"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e51d41689f551b4d1f678be2b6dd6e1cf87c961b8899bdb96a048491234354dc"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:824cf194bb50863f1ff6de6f1aa04693bbb9743981dcdc35a98549c6bf829d01"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb7a110b439ba3ee4986d19234e6ef00b36a5f8e9747896c24498fa23e684514"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b8dcf09453b0b0f4dc64efb35148cab8a0fb6c466d34e5cefd96ca6ab7fdb4e"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2f24708f6906b0883669c9eb4e67d0f65519f03530bae82b2b277ef62ec46ac7"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9681f9e4d19307666a84f6c0f3706b22d35eeaeeab07ac356b1393b00f97cac"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2892b50be613d1458a85106e0c1a21a9e8fd317e24028e8fae61be022870c9cd"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1b49947c5f0c7543fdab825e9375edcd407f85250d077e0a404844961d888c9b"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ec5324f6fda41e72f49830cb0b8d124b9431c2e3d4928fb0bd28d461dd6657d4"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:e23cec8f517f8dcd3fc7f13d2793616b92b1b2fd36c3759c92758f8166ecd154"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:420f4544bf230835e39786f55542d75108015a27dfd94779440cffb08d3762c8"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:550515f4a2e7051bbae343851a9ec3adc7edb1656b181b2a8ee571ae7fe8a21e"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-win32.whl", hash = "sha256:632d5473ba52da7fa71573c460d5fef470b3ec6d560348a07f97f2860b16f791"},
+    {file = "rapidfuzz-2.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae44dc7a350deaf92d313369b46280b787e52b99103437c46002ce29b3ba85eb"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f4107e92744bd1fd83fd38058aee3858893a4ab5b4eab76a758eb13804c38692"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:666bad2454b2fabd14e397fd467edc95e57f6324eb8bfc8c13f962732a4cba4e"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:03aa67c2eaf33391317598ea688a6cb522a9823c8d8a8eee9c85dc60b6fcbbc8"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f22a9f8d97766e18179ddc3251027ef346177335518826592d6e2862c811a4c7"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:313f3609fe37153d50436884d852aee3a56ac41734c807718d8453bd3c243565"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2fb5bac25bb5b0d6833f7b740292651759dab870f0487911def46214526f5dc9"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bc26a506c758bed4bf5b43b90a8c79460e76e28db97330cb6640287468d575d"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c5029ddb65ae980bcb87b9790df226105266f7c794b20cb32793b4865564e01"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4f393b18d411b590309693e4106fab09dc692f564e6fea4a744a33754f7b6a37"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:8d7e73e36fac74877b8a4700e60c9d699eabd48f7fd37419eb5f8124ed023273"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b3a125e32831a4370096903f0c2cc1314cf2ceae3af4431ac4885e53984201a5"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:c32d41dce29d0d14a393de443a1980001bf341b2dc977fab73cbb46be3beb10f"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fb4b8e3a52f2f28944499ab6b95817419e482b48cd11d776034ea4c98ea9e33f"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-win32.whl", hash = "sha256:4cd63b1debe72535d7b72de98c50571859954ffb3e5ffc5b0869feb29c407013"},
+    {file = "rapidfuzz-2.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:06b65e724cdca4eda6a639d491339445f140d88a598bc0eb98be80147003dc26"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:12b1d47eeb04b261f686bf29e4443807f8f953a0918aa5cc3ff1f4d3d48c64a5"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ad14814b68719f1e31d03751fa0dae5b30012c56a5155959443030134616eb4"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2886b2bf740353eace1a942844df2b6bbcfca69717cb4aac033681983e306856"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d31c7ba453a811bfdcd802f1a4703a21d7301ccdb91d81d92093eaceafb14a30"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24113e4afa1a6ca810f969ab996146bdbdcd338b35f115f935ae63d6b8d2aa75"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d63cc530b49ce0afb1aadf3d11bb0f52220a221e799715f63a8b77dea152cf"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:210af56001533ed1d8c7d5d0e57081877ba35a9391fb36d0a606693b0bd15d49"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9bc3f66189967b1504f617c09b295b6a8ad3a34a63e713c5553068bceb21c351"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:367f70a0c8bb19684c38973fe54888bd9179e991253547c4ee116a17f3d44319"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:5461e4cb215989c52872a886a1217e08af5de4c565c8bf356ab0f331dcfb8763"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b97bb1b3e32700e6bce2036c9435532a6dc45a5df8af8a7b842038b2eeaf3f9d"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-win32.whl", hash = "sha256:d9ec6429508ab1f2b752163970f26f4a179746c34c4862d3b3c2410be09d4fea"},
+    {file = "rapidfuzz-2.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:be0b533a3909c1db82e7a3c03e533374c71441dded616b71f222c4edd0058a52"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6c446c31468da2a08ec874baaeada06f3af6cede2b3010a2f0fccc5a95c3997d"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:577620e28f2b407231f293c58b24b1a7861ddd8092b7e6c6ba34b9945b5aa0a5"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:43e397ba21f6a53c6982c8ad0aae1ed5375d3e12089a9ede6c63c0fbffdb5354"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efe5d6b97366dc0c0ec575212441ccaebec5c7669a0a91f4dca5e751a6cace8"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c63637a74e00913c59bad6988cdf247c7ddc07b4f52cb4a3b15f08ebf90c2556"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5103b0be98271131ea992c62544b788f9afb90bbc716e5799b660dbca7b2959d"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a98614ad176a7ee719e3f30313f910a79ce17adbeea1f06bd4a1c5c997af762"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fecb07d87739912153b532bc1b5edbe3ecdf32a20e219d9bb02ef411d4c7638"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9662c286e493b7dc8e05363c63284889874097d6a594200702dd5703f76ad310"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b7717d489b65199a61e32cc87ad2e0a21b93b11de5f0873c91bcb77bfccda1cd"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:d10bb6fbf7e1f4f43a3b5a15e4cae28e52ade397704fa0f4566cf651ac23897e"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:6d0734d368eb6ab131d2644e0119a2d9164be9670de493391694ff647902f4ac"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5ef94ed9e3b371f935643cffb967a8090bd7c08e8a4a62523ffbc108bb57b8df"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-win32.whl", hash = "sha256:520865826b038ebf8e099bc7e58e424be14173c8ec72f41944f35c5190761a0c"},
+    {file = "rapidfuzz-2.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:bcfcf5ea72fe3bbdc7b7e716a1eca37dd610ab95fb1d8095ec274c9ebe2ebc5a"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e411ed96be9c4dacfbec3b8bd6873b18fa012da11ab544df32b8855b163a3317"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c2d014e8ca0b7a1e67ca9ee68ab04aa3524134dda33454a33b94404a0f67cfc2"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6580b5e837cd7776b454608caa62e9745be20c2c5f38e3d25aeca1f4ba7f125e"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cdafc456bd327fef05922a73b16ab9ccfdd7108456886456a119517d7c34292"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e8ef7ec8f3b9bdcf4b436b2bcd11fff5d1157404bc7bb501f51d7bfc85b7171"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9790024ef1bde76f62989b59131f17fa6c4bea0f16850aa79774225a079c243f"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00a960016fd801956f619f9c926bf72b8b8010e9b12dee2220357d59d9e4116e"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85d9ddb396914fa807179073d9f8c576376bbda34d52d699c5a41327938d4e1f"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2a9daf38dd701ce778cf9f5da7c1abc3a2d327d1106bc0d73fe2a33dbfa846f4"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2f6b79bff288d9eb59c6289bd0c92f876e241badfcd205b8087e6140b30a2b36"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:b48fb352b5d4436878a9b7062a648fc7fde77948ccd6fba454fe16c4ee367feb"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:830138acb8f57005f37ceec6dc74cd05482c5989c8ca4dba77883dd213039828"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:50817a5ce7c8e05434d4a40ff23dfb208a91f622af7fb41325a6dfeffcc0b3a8"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-win32.whl", hash = "sha256:a5c6b502600a3e33b536971989e336d1e1ec19c9acbcdc7ea606ea20061134a4"},
+    {file = "rapidfuzz-2.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:c5cacf2f1d1b5e79b091717393a50c9b24b703bca9c84d35c942c188ced67910"},
+    {file = "rapidfuzz-2.15.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:76f0248da712ea4abed9e6962873d41cc5fb13777455b4c811b3f9a853fd7e28"},
+    {file = "rapidfuzz-2.15.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f0cb2352b8e64e1804db4c0d91963161d54ce174b1b5575d15da1faf4aace9"},
+    {file = "rapidfuzz-2.15.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4f618620253849bb9542a10d23f4c2fc8ac0e06fb485be14312fd494cf48751"},
+    {file = "rapidfuzz-2.15.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f4fd9e5d7a09a60cb8cd0af2ff4abcbd5d8e9ea17304344a03f06cfbe4909b0"},
+    {file = "rapidfuzz-2.15.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d6ca92a5dfd9c97e8d2652ab56ab041d118e0ddf3009f7ae2cb9de7a19688b5d"},
+    {file = "rapidfuzz-2.15.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f04ac54dba649d3238295c2ff3a01cb9b5bfeb856d375253fd4f6ae2c0152a39"},
+    {file = "rapidfuzz-2.15.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f01d4c96824721e8292182d3270178021ff3d6065598e74fec5cf4b1e794fb2"},
+    {file = "rapidfuzz-2.15.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b6822b7be49785664cb72ce9ae8df67578154f6a8cf69e5be5ce7c25580a157"},
+    {file = "rapidfuzz-2.15.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c412ede384f3f305a202de4ef5f5b57394b41e213e77df97a33fd45f5837d854"},
+    {file = "rapidfuzz-2.15.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:0f570d61288b35bf2ff94f6d60c364fe3a78fc7ae71e7b149daeb2bc38dad1c7"},
+    {file = "rapidfuzz-2.15.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:62d7fa522c56908cbc9e9ead2a52f19ac818cd525474639ec8ee5eb2adab90df"},
+    {file = "rapidfuzz-2.15.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:462852ef50dced87e1e83ad92520b993afba4e7a4e6e93dbdfcdda449124df9e"},
+    {file = "rapidfuzz-2.15.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:766846a4df99c473d4426e51934421f767db07fa3a4e4d921bb5258a9f8b9a75"},
+    {file = "rapidfuzz-2.15.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fee1e39cdf8361aed89bdcf9bcdcdd47bd3714f16611fcfca46f408d983a661"},
+    {file = "rapidfuzz-2.15.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:684ac35c6480561b4a0067319112907e2405a93cb6a228de8214b6a3e86556fd"},
+    {file = "rapidfuzz-2.15.0.tar.gz", hash = "sha256:1c7e439d1428882d297bdd0db5626fc4626cdebe50d3fbbf4ed898f775ca56d5"},
 ]
 
 [package.extras]
@@ -1318,45 +1369,85 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-cache"
-version = "0.9.8"
-description = "A transparent persistent cache for the requests library"
+version = "1.0.1"
+description = "A persistent cache for python requests"
 category = "dev"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "requests_cache-0.9.8-py3-none-any.whl", hash = "sha256:3a16021a4b5014b5b32af9c34f07cb911e99a69074d664dfd4fddb62a2997c21"},
-    {file = "requests_cache-0.9.8.tar.gz", hash = "sha256:eaed4eb5fd5c392ba5e7cfa000d4ab96b1d32c1a1620f37aa558c43741ac362b"},
+    {file = "requests_cache-1.0.1-py3-none-any.whl", hash = "sha256:55c5765c26fd98a38c633d6e3931a507b7708cdd07c0afb48773d0718ac15969"},
+    {file = "requests_cache-1.0.1.tar.gz", hash = "sha256:d42e6c2f11de54e6a134c9a00c5ca2a3c8edde3c3f2bdfd942586fafa8990e14"},
 ]
 
 [package.dependencies]
-appdirs = ">=1.4.4"
 attrs = ">=21.2"
 cattrs = ">=22.2"
+platformdirs = ">=2.5"
 requests = ">=2.22"
 url-normalize = ">=1.4"
 urllib3 = ">=1.25.5"
 
 [package.extras]
-all = ["boto3 (>=1.15)", "botocore (>=1.18)", "itsdangerous (>=2.0)", "pymongo (>=3)", "pyyaml (>=5.4)", "redis (>=3)", "ujson (>=4.0)"]
+all = ["boto3 (>=1.15)", "botocore (>=1.18)", "itsdangerous (>=2.0)", "pymongo (>=3)", "pyyaml (>=5.4)", "redis (>=3)", "ujson (>=5.4)"]
 bson = ["bson (>=0.5)"]
-docs = ["furo (>=2021.9.8)", "linkify-it-py (>=1.0.1,<2.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx (==4.3.0)", "sphinx-autodoc-typehints (>=1.11,<2.0)", "sphinx-automodapi (>=0.13,<0.15)", "sphinx-copybutton (>=0.3,<0.5)", "sphinx-inline-tabs (>=2022.1.2b11)", "sphinx-notfound-page (>=0.8)", "sphinx-panels (>=0.6,<0.7)", "sphinxcontrib-apidoc (>=0.3,<0.4)"]
+docs = ["furo (>=2022.12.7,<2023.0.0)", "linkify-it-py (>=2.0,<3.0)", "myst-parser (>=1.0,<2.0)", "sphinx (>=5.0.2,<6.0.0)", "sphinx-autodoc-typehints (>=1.19)", "sphinx-automodapi (>=0.14)", "sphinx-copybutton (>=0.5)", "sphinx-design (>=0.2)", "sphinx-notfound-page (>=0.8)", "sphinxcontrib-apidoc (>=0.3)", "sphinxext-opengraph (>=0.6)"]
 dynamodb = ["boto3 (>=1.15)", "botocore (>=1.18)"]
-json = ["ujson (>=4.0)"]
+json = ["ujson (>=5.4)"]
 mongodb = ["pymongo (>=3)"]
 redis = ["redis (>=3)"]
 security = ["itsdangerous (>=2.0)"]
 yaml = ["pyyaml (>=5.4)"]
 
 [[package]]
+name = "rich"
+version = "13.3.3"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.3.3-py3-none-any.whl", hash = "sha256:540c7d6d26a1178e8e8b37e9ba44573a3cd1464ff6348b99ee7061b95d1c6333"},
+    {file = "rich-13.3.3.tar.gz", hash = "sha256:dc84400a9d842b3a9c5ff74addd8eb798d155f36c1c91303888e0a66850d2a15"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0,<3.0.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rich-click"
+version = "1.6.1"
+description = "Format click help output nicely with rich"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "rich-click-1.6.1.tar.gz", hash = "sha256:f8ff96693ec6e261d1544e9f7d9a5811c5ef5d74c8adb4978430fc0dac16777e"},
+    {file = "rich_click-1.6.1-py3-none-any.whl", hash = "sha256:0fcf4d1a09029d79322dd814ab0b2e66ac183633037561881d45abae8a161d95"},
+]
+
+[package.dependencies]
+click = ">=7"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+rich = ">=10.7.0"
+
+[package.extras]
+dev = ["pre-commit"]
+
+[[package]]
 name = "setuptools"
-version = "66.1.1"
+version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
+    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
+    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
 ]
 
 [package.extras]
@@ -1414,14 +1505,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.3.2.post1"
+version = "2.4"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
-    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
+    {file = "soupsieve-2.4-py3-none-any.whl", hash = "sha256:49e5368c2cda80ee7e84da9dbe3e110b70a4575f196efb74e51b94549d921955"},
+    {file = "soupsieve-2.4.tar.gz", hash = "sha256:e28dba9ca6c7c00173e34e4ba57448f0688bb681b7c5e8bf4971daafc093d69a"},
 ]
 
 [[package]]
@@ -1488,26 +1579,26 @@ files = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.5"
+version = "6.0.12.9"
 description = "Typing stubs for PyYAML"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-PyYAML-6.0.12.5.tar.gz", hash = "sha256:3b61b7a8111ce368eb366e4a13f3e94e568bc2ed6227e01520a50ee07993bf38"},
-    {file = "types_PyYAML-6.0.12.5-py3-none-any.whl", hash = "sha256:dcaf87b65b839e7b641721346ef8b12a87f94071e15205a64ac93ca0e0afc77a"},
+    {file = "types-PyYAML-6.0.12.9.tar.gz", hash = "sha256:c51b1bd6d99ddf0aa2884a7a328810ebf70a4262c292195d3f4f9a0005f9eeb6"},
+    {file = "types_PyYAML-6.0.12.9-py3-none-any.whl", hash = "sha256:5aed5aa66bd2d2e158f75dda22b059570ede988559f030cf294871d3b647e3e8"},
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
@@ -1527,14 +1618,14 @@ six = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.14"
+version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
-    {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
 ]
 
 [package.extras]
@@ -1544,40 +1635,39 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "watchdog"
-version = "2.2.1"
+version = "3.0.0"
 description = "Filesystem events monitoring"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "watchdog-2.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260"},
-    {file = "watchdog-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5100eae58133355d3ca6c1083a33b81355c4f452afa474c2633bd2fbbba398b3"},
-    {file = "watchdog-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e618a4863726bc7a3c64f95c218437f3349fb9d909eb9ea3a1ed3b567417c661"},
-    {file = "watchdog-2.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:102a60093090fc3ff76c983367b19849b7cc24ec414a43c0333680106e62aae1"},
-    {file = "watchdog-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:748ca797ff59962e83cc8e4b233f87113f3cf247c23e6be58b8a2885c7337aa3"},
-    {file = "watchdog-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6ccd8d84b9490a82b51b230740468116b8205822ea5fdc700a553d92661253a3"},
-    {file = "watchdog-2.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6e01d699cd260d59b84da6bda019dce0a3353e3fcc774408ae767fe88ee096b7"},
-    {file = "watchdog-2.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8586d98c494690482c963ffb24c49bf9c8c2fe0589cec4dc2f753b78d1ec301d"},
-    {file = "watchdog-2.2.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:adaf2ece15f3afa33a6b45f76b333a7da9256e1360003032524d61bdb4c422ae"},
-    {file = "watchdog-2.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:83a7cead445008e880dbde833cb9e5cc7b9a0958edb697a96b936621975f15b9"},
-    {file = "watchdog-2.2.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8ac23ff2c2df4471a61af6490f847633024e5aa120567e08d07af5718c9d092"},
-    {file = "watchdog-2.2.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d0f29fd9f3f149a5277929de33b4f121a04cf84bb494634707cfa8ea8ae106a8"},
-    {file = "watchdog-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:967636031fa4c4955f0f3f22da3c5c418aa65d50908d31b73b3b3ffd66d60640"},
-    {file = "watchdog-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96cbeb494e6cbe3ae6aacc430e678ce4b4dd3ae5125035f72b6eb4e5e9eb4f4e"},
-    {file = "watchdog-2.2.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:61fdb8e9c57baf625e27e1420e7ca17f7d2023929cd0065eb79c83da1dfbeacd"},
-    {file = "watchdog-2.2.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4cb5ecc332112017fbdb19ede78d92e29a8165c46b68a0b8ccbd0a154f196d5e"},
-    {file = "watchdog-2.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a480d122740debf0afac4ddd583c6c0bb519c24f817b42ed6f850e2f6f9d64a8"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:978a1aed55de0b807913b7482d09943b23a2d634040b112bdf31811a422f6344"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_armv7l.whl", hash = "sha256:8c28c23972ec9c524967895ccb1954bc6f6d4a557d36e681a36e84368660c4ce"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_i686.whl", hash = "sha256:c27d8c1535fd4474e40a4b5e01f4ba6720bac58e6751c667895cbc5c8a7af33c"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_ppc64.whl", hash = "sha256:d6b87477752bd86ac5392ecb9eeed92b416898c30bd40c7e2dd03c3146105646"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:cece1aa596027ff56369f0b50a9de209920e1df9ac6d02c7f9e5d8162eb4f02b"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:8b5cde14e5c72b2df5d074774bdff69e9b55da77e102a91f36ef26ca35f9819c"},
-    {file = "watchdog-2.2.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e038be858425c4f621900b8ff1a3a1330d9edcfeaa1c0468aeb7e330fb87693e"},
-    {file = "watchdog-2.2.1-py3-none-win32.whl", hash = "sha256:bc43c1b24d2f86b6e1cc15f68635a959388219426109233e606517ff7d0a5a73"},
-    {file = "watchdog-2.2.1-py3-none-win_amd64.whl", hash = "sha256:17f1708f7410af92ddf591e94ae71a27a13974559e72f7e9fde3ec174b26ba2e"},
-    {file = "watchdog-2.2.1-py3-none-win_ia64.whl", hash = "sha256:195ab1d9d611a4c1e5311cbf42273bc541e18ea8c32712f2fb703cfc6ff006f9"},
-    {file = "watchdog-2.2.1.tar.gz", hash = "sha256:cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:336adfc6f5cc4e037d52db31194f7581ff744b67382eb6021c868322e32eef41"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a70a8dcde91be523c35b2bf96196edc5730edb347e374c7de7cd20c43ed95397"},
+    {file = "watchdog-3.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:adfdeab2da79ea2f76f87eb42a3ab1966a5313e5a69a0213a3cc06ef692b0e96"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b57a1e730af3156d13b7fdddfc23dea6487fceca29fc75c5a868beed29177ae"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7ade88d0d778b1b222adebcc0927428f883db07017618a5e684fd03b83342bd9"},
+    {file = "watchdog-3.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7e447d172af52ad204d19982739aa2346245cc5ba6f579d16dac4bfec226d2e7"},
+    {file = "watchdog-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9fac43a7466eb73e64a9940ac9ed6369baa39b3bf221ae23493a9ec4d0022674"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8ae9cda41fa114e28faf86cb137d751a17ffd0316d1c34ccf2235e8a84365c7f"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25f70b4aa53bd743729c7475d7ec41093a580528b100e9a8c5b5efe8899592fc"},
+    {file = "watchdog-3.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4f94069eb16657d2c6faada4624c39464f65c05606af50bb7902e036e3219be3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7c5f84b5194c24dd573fa6472685b2a27cc5a17fe5f7b6fd40345378ca6812e3"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3aa7f6a12e831ddfe78cdd4f8996af9cf334fd6346531b16cec61c3b3c0d8da0"},
+    {file = "watchdog-3.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:233b5817932685d39a7896b1090353fc8efc1ef99c9c054e46c8002561252fb8"},
+    {file = "watchdog-3.0.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:13bbbb462ee42ec3c5723e1205be8ced776f05b100e4737518c67c8325cf6100"},
+    {file = "watchdog-3.0.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8f3ceecd20d71067c7fd4c9e832d4e22584318983cabc013dbf3f70ea95de346"},
+    {file = "watchdog-3.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c9d8c8ec7efb887333cf71e328e39cffbf771d8f8f95d308ea4125bf5f90ba64"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0e06ab8858a76e1219e68c7573dfeba9dd1c0219476c5a44d5333b01d7e1743a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:d00e6be486affb5781468457b21a6cbe848c33ef43f9ea4a73b4882e5f188a44"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:c07253088265c363d1ddf4b3cdb808d59a0468ecd017770ed716991620b8f77a"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:5113334cf8cf0ac8cd45e1f8309a603291b614191c9add34d33075727a967709"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:51f90f73b4697bac9c9a78394c3acbbd331ccd3655c11be1a15ae6fe289a8c83"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:ba07e92756c97e3aca0912b5cbc4e5ad802f4557212788e72a72a47ff376950d"},
+    {file = "watchdog-3.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d429c2430c93b7903914e4db9a966c7f2b068dd2ebdd2fa9b9ce094c7d459f33"},
+    {file = "watchdog-3.0.0-py3-none-win32.whl", hash = "sha256:3ed7c71a9dccfe838c2f0b6314ed0d9b22e77d268c67e015450a29036a81f60f"},
+    {file = "watchdog-3.0.0-py3-none-win_amd64.whl", hash = "sha256:4c9956d27be0bb08fc5f30d9d0179a855436e655f046d288e2bcc11adfae893c"},
+    {file = "watchdog-3.0.0-py3-none-win_ia64.whl", hash = "sha256:5d9f3a10e02d7371cd929b5d8f11e87d4bad890212ed3901f9b4d68767bee759"},
+    {file = "watchdog-3.0.0.tar.gz", hash = "sha256:4d98a320595da7a7c5a18fc48cb633c2e73cda78f93cac2ef42d42bf609a33f9"},
 ]
 
 [package.extras]
@@ -1585,14 +1675,14 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "websocket-client"
-version = "1.4.2"
+version = "1.5.1"
 description = "WebSocket client for Python with low level API options"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "websocket-client-1.4.2.tar.gz", hash = "sha256:d6e8f90ca8e2dd4e8027c4561adeb9456b54044312dba655e7cae652ceb9ae59"},
-    {file = "websocket_client-1.4.2-py3-none-any.whl", hash = "sha256:d6b06432f184438d99ac1f456eaf22fe1ade524c3dd16e661142dc54e9cba574"},
+    {file = "websocket-client-1.5.1.tar.gz", hash = "sha256:3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40"},
+    {file = "websocket_client-1.5.1-py3-none-any.whl", hash = "sha256:cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e"},
 ]
 
 [package.extras]
@@ -1602,93 +1692,104 @@ test = ["websockets"]
 
 [[package]]
 name = "wrapt"
-version = "1.14.1"
+version = "1.15.0"
 description = "Module for decorators, wrappers and monkey patching."
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 files = [
-    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
-    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
-    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
-    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
-    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
-    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
-    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
-    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
-    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
-    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+    {file = "wrapt-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46"},
+    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e"},
+    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a"},
+    {file = "wrapt-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923"},
+    {file = "wrapt-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7"},
+    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90"},
+    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975"},
+    {file = "wrapt-1.15.0-cp310-cp310-win32.whl", hash = "sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1"},
+    {file = "wrapt-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e"},
+    {file = "wrapt-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7"},
+    {file = "wrapt-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e"},
+    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92"},
+    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98"},
+    {file = "wrapt-1.15.0-cp311-cp311-win32.whl", hash = "sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416"},
+    {file = "wrapt-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb"},
+    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248"},
+    {file = "wrapt-1.15.0-cp35-cp35m-win32.whl", hash = "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559"},
+    {file = "wrapt-1.15.0-cp35-cp35m-win_amd64.whl", hash = "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"},
+    {file = "wrapt-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364"},
+    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418"},
+    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2"},
+    {file = "wrapt-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1"},
+    {file = "wrapt-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420"},
+    {file = "wrapt-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e"},
+    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034"},
+    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653"},
+    {file = "wrapt-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0"},
+    {file = "wrapt-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e"},
+    {file = "wrapt-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145"},
+    {file = "wrapt-1.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b"},
+    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094"},
+    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7"},
+    {file = "wrapt-1.15.0-cp38-cp38-win32.whl", hash = "sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b"},
+    {file = "wrapt-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1"},
+    {file = "wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86"},
+    {file = "wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc"},
+    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8"},
+    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9"},
+    {file = "wrapt-1.15.0-cp39-cp39-win32.whl", hash = "sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff"},
+    {file = "wrapt-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6"},
+    {file = "wrapt-1.15.0-py3-none-any.whl", hash = "sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640"},
+    {file = "wrapt-1.15.0.tar.gz", hash = "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a"},
 ]
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
+    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
-testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "neon-homeassistant-skill"
-version = "0.0.9"
+version = "0.0.10"
 description = "A Neon AI Skill for Home Assistant, which integrates with ovos-PHAL-plugin-homeassistant."
 authors = [ "Mike Gray <mike@graywind.org>" ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "neon-homeassistant-skill"
-version = "0.0.10"
+version = "0.0.11"
 description = "A Neon AI Skill for Home Assistant, which integrates with ovos-PHAL-plugin-homeassistant."
 authors = [ "Mike Gray <mike@graywind.org>" ]
 readme = "README.md"

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -21,1465 +21,1464 @@
 #        - expected_entity_key: expected_entity_value
 
 en-us:
-    close_dashboard.intent:
-        - close home assistant
-        - close the home assistant
-        - close my home assistant
-        - close home assistant dashboard
-        - close the home assistant dashboard
-        - close my home assistant dashboard
-        - open home assistant
+      close_dashboard.intent:
+            - close home assistant
+            - close the home assistant
+            - close my home assistant
+            - close home assistant dashboard
+            - close the home assistant dashboard
+            - close my home assistant dashboard
+            - open home assistant
 
-    open_dashboard.intent:
-        - open the home assistant
-        - open my home assistant
-        - open home assistant dashboard
-        - open the home assistant dashboard
-        - open my home assistant dashboard
-        - display home assistant dashboard
-        - display the home assistant dashboard
-        - display my home assistant dashboard
+      open_dashboard.intent:
+            - open the home assistant
+            - open my home assistant
+            - open home assistant dashboard
+            - open the home assistant dashboard
+            - open my home assistant dashboard
+            - display home assistant dashboard
+            - display the home assistant dashboard
+            - display my home assistant dashboard
 
-    stop_intent:
-        - stop the living room speaker:
-              - entity: living room speaker
-        - stop my living room speaker:
-              - entity: living room speaker
-        - Can you stop living room speaker please?:
-              - entity: living room speaker
-        - Can you stop the living room speaker please?:
-              - entity: living room speaker
-        - Can you stop my living room speaker please?:
-              - entity: living room speaker
-        - I'd like to stop living room speaker:
-              - entity: living room speaker
-        - I'd like to stop the living room speaker:
-              - entity: living room speaker
-        - I'd like to stop living room speaker:
-              - entity: living room speaker
-        - I'd like to stop the living room speaker:
-              - entity: living room speaker
-        - I'd like to stop my living room speaker:
-              - entity: living room speaker
-        - I would like living room speaker stopped:
-              - entity: living room speaker
-        - I would like the living room speaker stopped:
-              - entity: living room speaker
-        - I would like my living room speaker stopped:
-              - entity: living room speaker
+      stop_intent:
+            - stop the living room speaker:
+                    - entity: living room speaker
+            - stop my living room speaker:
+                    - entity: living room speaker
+            - Can you stop living room speaker please?:
+                    - entity: living room speaker
+            - Can you stop the living room speaker please?:
+                    - entity: living room speaker
+            - Can you stop my living room speaker please?:
+                    - entity: living room speaker
+            - I'd like to stop living room speaker:
+                    - entity: living room speaker
+            - I'd like to stop the living room speaker:
+                    - entity: living room speaker
+            - I'd like to stop living room speaker:
+                    - entity: living room speaker
+            - I'd like to stop the living room speaker:
+                    - entity: living room speaker
+            - I'd like to stop my living room speaker:
+                    - entity: living room speaker
+            - I would like living room speaker stopped:
+                    - entity: living room speaker
+            - I would like the living room speaker stopped:
+                    - entity: living room speaker
+            - I would like my living room speaker stopped:
+                    - entity: living room speaker
 
-    sensor.intent:
-        - What is  temperature of my living room speaker please:
-              - entity: living room speaker
-        - What is  temperature of my living room speaker:
-              - entity: living room speaker
-        - What is  temperature of the living room speaker please:
-              - entity: living room speaker
-        - What is  temperature of the living room speaker:
-              - entity: living room speaker
-        - What is  temperature of  living room speaker please:
-              - entity: living room speaker
-        - What is  temperature of  living room speaker:
-              - entity: living room speaker
-        - What is  hue of my living room speaker please:
-              - entity: living room speaker
-        - What is  hue of my living room speaker:
-              - entity: living room speaker
-        - What is  hue of the living room speaker please:
-              - entity: living room speaker
-        - What is  hue of the living room speaker:
-              - entity: living room speaker
-        - What is  hue of  living room speaker please:
-              - entity: living room speaker
-        - What is  hue of  living room speaker:
-              - entity: living room speaker
-        - What is  value of my living room speaker please:
-              - entity: living room speaker
-        - What is  value of my living room speaker:
-              - entity: living room speaker
-        - What is  value of the living room speaker please:
-              - entity: living room speaker
-        - What is  value of the living room speaker:
-              - entity: living room speaker
-        - What is  value of  living room speaker please:
-              - entity: living room speaker
-        - What is  value of  living room speaker:
-              - entity: living room speaker
-        - What is  state of my living room speaker please:
-              - entity: living room speaker
-        - What is  state of my living room speaker:
-              - entity: living room speaker
-        - What is  state of the living room speaker please:
-              - entity: living room speaker
-        - What is  state of the living room speaker:
-              - entity: living room speaker
-        - What is  state of  living room speaker please:
-              - entity: living room speaker
-        - What is  state of  living room speaker:
-              - entity: living room speaker
-        - What is  status of my living room speaker please:
-              - entity: living room speaker
-        - What is  status of my living room speaker:
-              - entity: living room speaker
-        - What is  status of the living room speaker please:
-              - entity: living room speaker
-        - What is  status of the living room speaker:
-              - entity: living room speaker
-        - What is  status of  living room speaker please:
-              - entity: living room speaker
-        - What is  status of  living room speaker:
-              - entity: living room speaker
-        - What is  read out of my living room speaker please:
-              - entity: living room speaker
-        - What is  read out of my living room speaker:
-              - entity: living room speaker
-        - What is  read out of the living room speaker please:
-              - entity: living room speaker
-        - What is  read out of the living room speaker:
-              - entity: living room speaker
-        - What is  read out of  living room speaker please:
-              - entity: living room speaker
-        - What is  read out of  living room speaker:
-              - entity: living room speaker
-        - What is the temperature of my living room speaker please:
-              - entity: living room speaker
-        - What is the temperature of my living room speaker:
-              - entity: living room speaker
-        - What is the temperature of the living room speaker please:
-              - entity: living room speaker
-        - What is the temperature of the living room speaker:
-              - entity: living room speaker
-        - What is the temperature of  living room speaker please:
-              - entity: living room speaker
-        - What is the temperature of  living room speaker:
-              - entity: living room speaker
-        - What is the hue of my living room speaker please:
-              - entity: living room speaker
-        - What is the hue of my living room speaker:
-              - entity: living room speaker
-        - What is the hue of the living room speaker please:
-              - entity: living room speaker
-        - What is the hue of the living room speaker:
-              - entity: living room speaker
-        - What is the hue of  living room speaker please:
-              - entity: living room speaker
-        - What is the hue of  living room speaker:
-              - entity: living room speaker
-        - What is the value of my living room speaker please:
-              - entity: living room speaker
-        - What is the value of my living room speaker:
-              - entity: living room speaker
-        - What is the value of the living room speaker please:
-              - entity: living room speaker
-        - What is the value of the living room speaker:
-              - entity: living room speaker
-        - What is the value of  living room speaker please:
-              - entity: living room speaker
-        - What is the value of  living room speaker:
-              - entity: living room speaker
-        - What is the state of my living room speaker please:
-              - entity: living room speaker
-        - What is the state of my living room speaker:
-              - entity: living room speaker
-        - What is the state of the living room speaker please:
-              - entity: living room speaker
-        - What is the state of the living room speaker:
-              - entity: living room speaker
-        - What is the state of  living room speaker please:
-              - entity: living room speaker
-        - What is the state of  living room speaker:
-              - entity: living room speaker
-        - What is the status of my living room speaker please:
-              - entity: living room speaker
-        - What is the status of my living room speaker:
-              - entity: living room speaker
-        - What is the status of the living room speaker please:
-              - entity: living room speaker
-        - What is the status of the living room speaker:
-              - entity: living room speaker
-        - What is the status of  living room speaker please:
-              - entity: living room speaker
-        - What is the status of  living room speaker:
-              - entity: living room speaker
-        - What is the read out of my living room speaker please:
-              - entity: living room speaker
-        - What is the read out of my living room speaker:
-              - entity: living room speaker
-        - What is the read out of the living room speaker please:
-              - entity: living room speaker
-        - What is the read out of the living room speaker:
-              - entity: living room speaker
-        - What is the read out of  living room speaker please:
-              - entity: living room speaker
-        - What is the read out of  living room speaker:
-              - entity: living room speaker
-        - Give me  temperature of my living room speaker please:
-              - entity: living room speaker
-        - Give me  temperature of my living room speaker:
-              - entity: living room speaker
-        - Give me  temperature of the living room speaker please:
-              - entity: living room speaker
-        - Give me  temperature of the living room speaker:
-              - entity: living room speaker
-        - Give me  temperature of  living room speaker please:
-              - entity: living room speaker
-        - Give me  temperature of  living room speaker:
-              - entity: living room speaker
-        - Give me  hue of my living room speaker please:
-              - entity: living room speaker
-        - Give me  hue of my living room speaker:
-              - entity: living room speaker
-        - Give me  hue of the living room speaker please:
-              - entity: living room speaker
-        - Give me  hue of the living room speaker:
-              - entity: living room speaker
-        - Give me  hue of  living room speaker please:
-              - entity: living room speaker
-        - Give me  hue of  living room speaker:
-              - entity: living room speaker
-        - Give me  value of my living room speaker please:
-              - entity: living room speaker
-        - Give me  value of my living room speaker:
-              - entity: living room speaker
-        - Give me  value of the living room speaker please:
-              - entity: living room speaker
-        - Give me  value of the living room speaker:
-              - entity: living room speaker
-        - Give me  value of  living room speaker please:
-              - entity: living room speaker
-        - Give me  value of  living room speaker:
-              - entity: living room speaker
-        - Give me  state of my living room speaker please:
-              - entity: living room speaker
-        - Give me  state of my living room speaker:
-              - entity: living room speaker
-        - Give me  state of the living room speaker please:
-              - entity: living room speaker
-        - Give me  state of the living room speaker:
-              - entity: living room speaker
-        - Give me  state of  living room speaker please:
-              - entity: living room speaker
-        - Give me  state of  living room speaker:
-              - entity: living room speaker
-        - Give me  status of my living room speaker please:
-              - entity: living room speaker
-        - Give me  status of my living room speaker:
-              - entity: living room speaker
-        - Give me  status of the living room speaker please:
-              - entity: living room speaker
-        - Give me  status of the living room speaker:
-              - entity: living room speaker
-        - Give me  status of  living room speaker please:
-              - entity: living room speaker
-        - Give me  status of  living room speaker:
-              - entity: living room speaker
-        - Give me  read out of my living room speaker please:
-              - entity: living room speaker
-        - Give me  read out of my living room speaker:
-              - entity: living room speaker
-        - Give me  read out of the living room speaker please:
-              - entity: living room speaker
-        - Give me  read out of the living room speaker:
-              - entity: living room speaker
-        - Give me  read out of  living room speaker please:
-              - entity: living room speaker
-        - Give me  read out of  living room speaker:
-              - entity: living room speaker
-        - Give me the temperature of my living room speaker please:
-              - entity: living room speaker
-        - Give me the temperature of my living room speaker:
-              - entity: living room speaker
-        - Give me the temperature of the living room speaker please:
-              - entity: living room speaker
-        - Give me the temperature of the living room speaker:
-              - entity: living room speaker
-        - Give me the temperature of  living room speaker please:
-              - entity: living room speaker
-        - Give me the temperature of  living room speaker:
-              - entity: living room speaker
-        - Give me the hue of my living room speaker please:
-              - entity: living room speaker
-        - Give me the hue of my living room speaker:
-              - entity: living room speaker
-        - Give me the hue of the living room speaker please:
-              - entity: living room speaker
-        - Give me the hue of the living room speaker:
-              - entity: living room speaker
-        - Give me the hue of  living room speaker please:
-              - entity: living room speaker
-        - Give me the hue of  living room speaker:
-              - entity: living room speaker
-        - Give me the value of my living room speaker please:
-              - entity: living room speaker
-        - Give me the value of my living room speaker:
-              - entity: living room speaker
-        - Give me the value of the living room speaker please:
-              - entity: living room speaker
-        - Give me the value of the living room speaker:
-              - entity: living room speaker
-        - Give me the value of  living room speaker please:
-              - entity: living room speaker
-        - Give me the value of  living room speaker:
-              - entity: living room speaker
-        - Give me the state of my living room speaker please:
-              - entity: living room speaker
-        - Give me the state of my living room speaker:
-              - entity: living room speaker
-        - Give me the state of the living room speaker please:
-              - entity: living room speaker
-        - Give me the state of the living room speaker:
-              - entity: living room speaker
-        - Give me the state of  living room speaker please:
-              - entity: living room speaker
-        - Give me the state of  living room speaker:
-              - entity: living room speaker
-        - Give me the status of my living room speaker please:
-              - entity: living room speaker
-        - Give me the status of my living room speaker:
-              - entity: living room speaker
-        - Give me the status of the living room speaker please:
-              - entity: living room speaker
-        - Give me the status of the living room speaker:
-              - entity: living room speaker
-        - Give me the status of  living room speaker please:
-              - entity: living room speaker
-        - Give me the status of  living room speaker:
-              - entity: living room speaker
-        - Give me the read out of my living room speaker please:
-              - entity: living room speaker
-        - Give me the read out of my living room speaker:
-              - entity: living room speaker
-        - Give me the read out of the living room speaker please:
-              - entity: living room speaker
-        - Give me the read out of the living room speaker:
-              - entity: living room speaker
-        - Give me the read out of  living room speaker please:
-              - entity: living room speaker
-        - Give me the read out of  living room speaker:
-              - entity: living room speaker
-        - Tell me  temperature of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  temperature of my living room speaker:
-              - entity: living room speaker
-        - Tell me  temperature of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  temperature of the living room speaker:
-              - entity: living room speaker
-        - Tell me  temperature of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  temperature of  living room speaker:
-              - entity: living room speaker
-        - Tell me  hue of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  hue of my living room speaker:
-              - entity: living room speaker
-        - Tell me  hue of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  hue of the living room speaker:
-              - entity: living room speaker
-        - Tell me  hue of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  hue of  living room speaker:
-              - entity: living room speaker
-        - Tell me  value of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  value of my living room speaker:
-              - entity: living room speaker
-        - Tell me  value of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  value of the living room speaker:
-              - entity: living room speaker
-        - Tell me  value of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  value of  living room speaker:
-              - entity: living room speaker
-        - Tell me  state of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  state of my living room speaker:
-              - entity: living room speaker
-        - Tell me  state of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  state of the living room speaker:
-              - entity: living room speaker
-        - Tell me  state of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  state of  living room speaker:
-              - entity: living room speaker
-        - Tell me  status of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  status of my living room speaker:
-              - entity: living room speaker
-        - Tell me  status of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  status of the living room speaker:
-              - entity: living room speaker
-        - Tell me  status of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  status of  living room speaker:
-              - entity: living room speaker
-        - Tell me  read out of my living room speaker please:
-              - entity: living room speaker
-        - Tell me  read out of my living room speaker:
-              - entity: living room speaker
-        - Tell me  read out of the living room speaker please:
-              - entity: living room speaker
-        - Tell me  read out of the living room speaker:
-              - entity: living room speaker
-        - Tell me  read out of  living room speaker please:
-              - entity: living room speaker
-        - Tell me  read out of  living room speaker:
-              - entity: living room speaker
-        - Tell me the temperature of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the temperature of my living room speaker:
-              - entity: living room speaker
-        - Tell me the temperature of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the temperature of the living room speaker:
-              - entity: living room speaker
-        - Tell me the temperature of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the temperature of  living room speaker:
-              - entity: living room speaker
-        - Tell me the hue of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the hue of my living room speaker:
-              - entity: living room speaker
-        - Tell me the hue of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the hue of the living room speaker:
-              - entity: living room speaker
-        - Tell me the hue of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the hue of  living room speaker:
-              - entity: living room speaker
-        - Tell me the value of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the value of my living room speaker:
-              - entity: living room speaker
-        - Tell me the value of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the value of the living room speaker:
-              - entity: living room speaker
-        - Tell me the value of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the value of  living room speaker:
-              - entity: living room speaker
-        - Tell me the state of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the state of my living room speaker:
-              - entity: living room speaker
-        - Tell me the state of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the state of the living room speaker:
-              - entity: living room speaker
-        - Tell me the state of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the state of  living room speaker:
-              - entity: living room speaker
-        - Tell me the status of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the status of my living room speaker:
-              - entity: living room speaker
-        - Tell me the status of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the status of the living room speaker:
-              - entity: living room speaker
-        - Tell me the status of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the status of  living room speaker:
-              - entity: living room speaker
-        - Tell me the read out of my living room speaker please:
-              - entity: living room speaker
-        - Tell me the read out of my living room speaker:
-              - entity: living room speaker
-        - Tell me the read out of the living room speaker please:
-              - entity: living room speaker
-        - Tell me the read out of the living room speaker:
-              - entity: living room speaker
-        - Tell me the read out of  living room speaker please:
-              - entity: living room speaker
-        - Tell me the read out of  living room speaker:
-              - entity: living room speaker
-        - Get  temperature of my living room speaker please:
-              - entity: living room speaker
-        - Get  temperature of my living room speaker:
-              - entity: living room speaker
-        - Get  temperature of the living room speaker please:
-              - entity: living room speaker
-        - Get  temperature of the living room speaker:
-              - entity: living room speaker
-        - Get  temperature of  living room speaker please:
-              - entity: living room speaker
-        - Get  temperature of  living room speaker:
-              - entity: living room speaker
-        - Get  hue of my living room speaker please:
-              - entity: living room speaker
-        - Get  hue of my living room speaker:
-              - entity: living room speaker
-        - Get  hue of the living room speaker please:
-              - entity: living room speaker
-        - Get  hue of the living room speaker:
-              - entity: living room speaker
-        - Get  hue of  living room speaker please:
-              - entity: living room speaker
-        - Get  hue of  living room speaker:
-              - entity: living room speaker
-        - Get  value of my living room speaker please:
-              - entity: living room speaker
-        - Get  value of my living room speaker:
-              - entity: living room speaker
-        - Get  value of the living room speaker please:
-              - entity: living room speaker
-        - Get  value of the living room speaker:
-              - entity: living room speaker
-        - Get  value of  living room speaker please:
-              - entity: living room speaker
-        - Get  value of  living room speaker:
-              - entity: living room speaker
-        - Get  state of my living room speaker please:
-              - entity: living room speaker
-        - Get  state of my living room speaker:
-              - entity: living room speaker
-        - Get  state of the living room speaker please:
-              - entity: living room speaker
-        - Get  state of the living room speaker:
-              - entity: living room speaker
-        - Get  state of  living room speaker please:
-              - entity: living room speaker
-        - Get  state of  living room speaker:
-              - entity: living room speaker
-        - Get  status of my living room speaker please:
-              - entity: living room speaker
-        - Get  status of my living room speaker:
-              - entity: living room speaker
-        - Get  status of the living room speaker please:
-              - entity: living room speaker
-        - Get  status of the living room speaker:
-              - entity: living room speaker
-        - Get  status of  living room speaker please:
-              - entity: living room speaker
-        - Get  status of  living room speaker:
-              - entity: living room speaker
-        - Get  read out of my living room speaker please:
-              - entity: living room speaker
-        - Get  read out of my living room speaker:
-              - entity: living room speaker
-        - Get  read out of the living room speaker please:
-              - entity: living room speaker
-        - Get  read out of the living room speaker:
-              - entity: living room speaker
-        - Get  read out of  living room speaker please:
-              - entity: living room speaker
-        - Get  read out of  living room speaker:
-              - entity: living room speaker
-        - Get the temperature of my living room speaker please:
-              - entity: living room speaker
-        - Get the temperature of my living room speaker:
-              - entity: living room speaker
-        - Get the temperature of the living room speaker please:
-              - entity: living room speaker
-        - Get the temperature of the living room speaker:
-              - entity: living room speaker
-        - Get the temperature of  living room speaker please:
-              - entity: living room speaker
-        - Get the temperature of  living room speaker:
-              - entity: living room speaker
-        - Get the hue of my living room speaker please:
-              - entity: living room speaker
-        - Get the hue of my living room speaker:
-              - entity: living room speaker
-        - Get the hue of the living room speaker please:
-              - entity: living room speaker
-        - Get the hue of the living room speaker:
-              - entity: living room speaker
-        - Get the hue of  living room speaker please:
-              - entity: living room speaker
-        - Get the hue of  living room speaker:
-              - entity: living room speaker
-        - Get the value of my living room speaker please:
-              - entity: living room speaker
-        - Get the value of my living room speaker:
-              - entity: living room speaker
-        - Get the value of the living room speaker please:
-              - entity: living room speaker
-        - Get the value of the living room speaker:
-              - entity: living room speaker
-        - Get the value of  living room speaker please:
-              - entity: living room speaker
-        - Get the value of  living room speaker:
-              - entity: living room speaker
-        - Get the state of my living room speaker please:
-              - entity: living room speaker
-        - Get the state of my living room speaker:
-              - entity: living room speaker
-        - Get the state of the living room speaker please:
-              - entity: living room speaker
-        - Get the state of the living room speaker:
-              - entity: living room speaker
-        - Get the state of  living room speaker please:
-              - entity: living room speaker
-        - Get the state of  living room speaker:
-              - entity: living room speaker
-        - Get the status of my living room speaker please:
-              - entity: living room speaker
-        - Get the status of my living room speaker:
-              - entity: living room speaker
-        - Get the status of the living room speaker please:
-              - entity: living room speaker
-        - Get the status of the living room speaker:
-              - entity: living room speaker
-        - Get the status of  living room speaker please:
-              - entity: living room speaker
-        - Get the status of  living room speaker:
-              - entity: living room speaker
-        - Get the read out of my living room speaker please:
-              - entity: living room speaker
-        - Get the read out of my living room speaker:
-              - entity: living room speaker
-        - Get the read out of the living room speaker please:
-              - entity: living room speaker
-        - Get the read out of the living room speaker:
-              - entity: living room speaker
-        - Get the read out of  living room speaker please:
-              - entity: living room speaker
-        - Get the read out of  living room speaker:
-              - entity: living room speaker
-        - is my living room speaker on:
-              - entity: living room speaker
-        - is my living room speaker off:
-              - entity: living room speaker
-        - is my living room speaker high:
-              - entity: living room speaker
-        - is my living room speaker low:
-              - entity: living room speaker
-        - is my living room speaker cold:
-              - entity: living room speaker
-        - is my living room speaker warm:
-              - entity: living room speaker
-        - is my living room speaker hot:
-              - entity: living room speaker
-        - is my living room speaker connected:
-              - entity: living room speaker
-        - is my living room speaker disconnected:
-              - entity: living room speaker
-        - is my living room speaker open:
-              - entity: living room speaker
-        - is my living room speaker closed:
-              - entity: living room speaker
-        - is my living room speaker dark:
-              - entity: living room speaker
-        - is my living room speaker in motion:
-              - entity: living room speaker
-        - is my living room speaker occupied:
-              - entity: living room speaker
-        - is my living room speaker plugged in:
-              - entity: living room speaker
-        - is my living room speaker secure:
-              - entity: living room speaker
-        - is my living room speaker unsecure:
-              - entity: living room speaker
-        - is my living room speaker charging:
-              - entity: living room speaker
-        - is my living room speaker available:
-              - entity: living room speaker
-        - is the living room speaker on:
-              - entity: living room speaker
-        - is the living room speaker off:
-              - entity: living room speaker
-        - is the living room speaker high:
-              - entity: living room speaker
-        - is the living room speaker low:
-              - entity: living room speaker
-        - is the living room speaker cold:
-              - entity: living room speaker
-        - is the living room speaker warm:
-              - entity: living room speaker
-        - is the living room speaker hot:
-              - entity: living room speaker
-        - is the living room speaker connected:
-              - entity: living room speaker
-        - is the living room speaker disconnected:
-              - entity: living room speaker
-        - is the living room speaker open:
-              - entity: living room speaker
-        - is the living room speaker closed:
-              - entity: living room speaker
-        - is the living room speaker dark:
-              - entity: living room speaker
-        - is the living room speaker in motion:
-              - entity: living room speaker
-        - is the living room speaker occupied:
-              - entity: living room speaker
-        - is the living room speaker plugged in:
-              - entity: living room speaker
-        - is the living room speaker secure:
-              - entity: living room speaker
-        - is the living room speaker unsecure:
-              - entity: living room speaker
-        - is the living room speaker charging:
-              - entity: living room speaker
-        - is the living room speaker available:
-              - entity: living room speaker
-        - is  living room speaker on:
-              - entity: living room speaker
-        - is  living room speaker off:
-              - entity: living room speaker
-        - is  living room speaker high:
-              - entity: living room speaker
-        - is  living room speaker low:
-              - entity: living room speaker
-        - is  living room speaker cold:
-              - entity: living room speaker
-        - is  living room speaker warm:
-              - entity: living room speaker
-        - is  living room speaker hot:
-              - entity: living room speaker
-        - is  living room speaker connected:
-              - entity: living room speaker
-        - is  living room speaker disconnected:
-              - entity: living room speaker
-        - is  living room speaker open:
-              - entity: living room speaker
-        - is  living room speaker closed:
-              - entity: living room speaker
-        - is  living room speaker dark:
-              - entity: living room speaker
-        - is  living room speaker in motion:
-              - entity: living room speaker
-        - is  living room speaker occupied:
-              - entity: living room speaker
-        - is  living room speaker plugged in:
-              - entity: living room speaker
-        - is  living room speaker secure:
-              - entity: living room speaker
-        - is  living room speaker unsecure:
-              - entity: living room speaker
-        - is  living room speaker charging:
-              - entity: living room speaker
-        - is  living room speaker available:
-              - entity: living room speaker
-        - has  living room speaker detected a moisture:
-              - entity: living room speaker
-        - has  living room speaker detected a energy:
-              - entity: living room speaker
-        - has  living room speaker detected a problem:
-              - entity: living room speaker
-        - has  living room speaker detected a vibration:
-              - entity: living room speaker
-        - has  living room speaker detected a gas:
-              - entity: living room speaker
-        - has  living room speaker detected a sound:
-              - entity: living room speaker
-        - has  living room speaker detected  moisture:
-              - entity: living room speaker
-        - has  living room speaker detected  energy:
-              - entity: living room speaker
-        - has  living room speaker detected  problem:
-              - entity: living room speaker
-        - has  living room speaker detected  vibration:
-              - entity: living room speaker
-        - has  living room speaker detected  gas:
-              - entity: living room speaker
-        - has  living room speaker detected  sound:
-              - entity: living room speaker
-        - has the living room speaker detected a moisture:
-              - entity: living room speaker
-        - has the living room speaker detected a energy:
-              - entity: living room speaker
-        - has the living room speaker detected a problem:
-              - entity: living room speaker
-        - has the living room speaker detected a vibration:
-              - entity: living room speaker
-        - has the living room speaker detected a gas:
-              - entity: living room speaker
-        - has the living room speaker detected a sound:
-              - entity: living room speaker
-        - has the living room speaker detected  moisture:
-              - entity: living room speaker
-        - has the living room speaker detected  energy:
-              - entity: living room speaker
-        - has the living room speaker detected  problem:
-              - entity: living room speaker
-        - has the living room speaker detected  vibration:
-              - entity: living room speaker
-        - has the living room speaker detected  gas:
-              - entity: living room speaker
-        - has the living room speaker detected  sound:
-              - entity: living room speaker
-        - has my living room speaker detected a moisture:
-              - entity: living room speaker
-        - has my living room speaker detected a energy:
-              - entity: living room speaker
-        - has my living room speaker detected a problem:
-              - entity: living room speaker
-        - has my living room speaker detected a vibration:
-              - entity: living room speaker
-        - has my living room speaker detected a gas:
-              - entity: living room speaker
-        - has my living room speaker detected a sound:
-              - entity: living room speaker
-        - has my living room speaker detected  moisture:
-              - entity: living room speaker
-        - has my living room speaker detected  energy:
-              - entity: living room speaker
-        - has my living room speaker detected  problem:
-              - entity: living room speaker
-        - has my living room speaker detected  vibration:
-              - entity: living room speaker
-        - has my living room speaker detected  gas:
-              - entity: living room speaker
-        - has my living room speaker detected  sound:
-              - entity: living room speaker
+      sensor.intent:
+            - What is  temperature of my living room speaker please:
+                    - entity: living room speaker
+            - What is  temperature of my living room speaker:
+                    - entity: living room speaker
+            - What is  temperature of the living room speaker please:
+                    - entity: living room speaker
+            - What is  temperature of the living room speaker:
+                    - entity: living room speaker
+            - What is  temperature of  living room speaker please:
+                    - entity: living room speaker
+            - What is  temperature of  living room speaker:
+                    - entity: living room speaker
+            - What is  hue of my living room speaker please:
+                    - entity: living room speaker
+            - What is  hue of my living room speaker:
+                    - entity: living room speaker
+            - What is  hue of the living room speaker please:
+                    - entity: living room speaker
+            - What is  hue of the living room speaker:
+                    - entity: living room speaker
+            - What is  hue of  living room speaker please:
+                    - entity: living room speaker
+            - What is  hue of  living room speaker:
+                    - entity: living room speaker
+            - What is  value of my living room speaker please:
+                    - entity: living room speaker
+            - What is  value of my living room speaker:
+                    - entity: living room speaker
+            - What is  value of the living room speaker please:
+                    - entity: living room speaker
+            - What is  value of the living room speaker:
+                    - entity: living room speaker
+            - What is  value of  living room speaker please:
+                    - entity: living room speaker
+            - What is  value of  living room speaker:
+                    - entity: living room speaker
+            - What is  state of my living room speaker please:
+                    - entity: living room speaker
+            - What is  state of my living room speaker:
+                    - entity: living room speaker
+            - What is  state of the living room speaker please:
+                    - entity: living room speaker
+            - What is  state of the living room speaker:
+                    - entity: living room speaker
+            - What is  state of  living room speaker please:
+                    - entity: living room speaker
+            - What is  state of  living room speaker:
+                    - entity: living room speaker
+            - What is  status of my living room speaker please:
+                    - entity: living room speaker
+            - What is  status of my living room speaker:
+                    - entity: living room speaker
+            - What is  status of the living room speaker please:
+                    - entity: living room speaker
+            - What is  status of the living room speaker:
+                    - entity: living room speaker
+            - What is  status of  living room speaker please:
+                    - entity: living room speaker
+            - What is  status of  living room speaker:
+                    - entity: living room speaker
+            - What is  read out of my living room speaker please:
+                    - entity: living room speaker
+            - What is  read out of my living room speaker:
+                    - entity: living room speaker
+            - What is  read out of the living room speaker please:
+                    - entity: living room speaker
+            - What is  read out of the living room speaker:
+                    - entity: living room speaker
+            - What is  read out of  living room speaker please:
+                    - entity: living room speaker
+            - What is  read out of  living room speaker:
+                    - entity: living room speaker
+            - What is the temperature of my living room speaker please:
+                    - entity: living room speaker
+            - What is the temperature of my living room speaker:
+                    - entity: living room speaker
+            - What is the temperature of the living room speaker please:
+                    - entity: living room speaker
+            - What is the temperature of the living room speaker:
+                    - entity: living room speaker
+            - What is the temperature of  living room speaker please:
+                    - entity: living room speaker
+            - What is the temperature of  living room speaker:
+                    - entity: living room speaker
+            - What is the hue of my living room speaker please:
+                    - entity: living room speaker
+            - What is the hue of my living room speaker:
+                    - entity: living room speaker
+            - What is the hue of the living room speaker please:
+                    - entity: living room speaker
+            - What is the hue of the living room speaker:
+                    - entity: living room speaker
+            - What is the hue of  living room speaker please:
+                    - entity: living room speaker
+            - What is the hue of  living room speaker:
+                    - entity: living room speaker
+            - What is the value of my living room speaker please:
+                    - entity: living room speaker
+            - What is the value of my living room speaker:
+                    - entity: living room speaker
+            - What is the value of the living room speaker please:
+                    - entity: living room speaker
+            - What is the value of the living room speaker:
+                    - entity: living room speaker
+            - What is the value of  living room speaker please:
+                    - entity: living room speaker
+            - What is the value of  living room speaker:
+                    - entity: living room speaker
+            - What is the state of my living room speaker please:
+                    - entity: living room speaker
+            - What is the state of my living room speaker:
+                    - entity: living room speaker
+            - What is the state of the living room speaker please:
+                    - entity: living room speaker
+            - What is the state of the living room speaker:
+                    - entity: living room speaker
+            - What is the state of  living room speaker please:
+                    - entity: living room speaker
+            - What is the state of  living room speaker:
+                    - entity: living room speaker
+            - What is the status of my living room speaker please:
+                    - entity: living room speaker
+            - What is the status of my living room speaker:
+                    - entity: living room speaker
+            - What is the status of the living room speaker please:
+                    - entity: living room speaker
+            - What is the status of the living room speaker:
+                    - entity: living room speaker
+            - What is the status of  living room speaker please:
+                    - entity: living room speaker
+            - What is the status of  living room speaker:
+                    - entity: living room speaker
+            - What is the read out of my living room speaker please:
+                    - entity: living room speaker
+            - What is the read out of my living room speaker:
+                    - entity: living room speaker
+            - What is the read out of the living room speaker please:
+                    - entity: living room speaker
+            - What is the read out of the living room speaker:
+                    - entity: living room speaker
+            - What is the read out of  living room speaker please:
+                    - entity: living room speaker
+            - What is the read out of  living room speaker:
+                    - entity: living room speaker
+            - Give me  temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  temperature of my living room speaker:
+                    - entity: living room speaker
+            - Give me  temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  temperature of the living room speaker:
+                    - entity: living room speaker
+            - Give me  temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  temperature of  living room speaker:
+                    - entity: living room speaker
+            - Give me  hue of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  hue of my living room speaker:
+                    - entity: living room speaker
+            - Give me  hue of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  hue of the living room speaker:
+                    - entity: living room speaker
+            - Give me  hue of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  hue of  living room speaker:
+                    - entity: living room speaker
+            - Give me  value of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  value of my living room speaker:
+                    - entity: living room speaker
+            - Give me  value of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  value of the living room speaker:
+                    - entity: living room speaker
+            - Give me  value of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  value of  living room speaker:
+                    - entity: living room speaker
+            - Give me  state of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  state of my living room speaker:
+                    - entity: living room speaker
+            - Give me  state of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  state of the living room speaker:
+                    - entity: living room speaker
+            - Give me  state of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  state of  living room speaker:
+                    - entity: living room speaker
+            - Give me  status of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  status of my living room speaker:
+                    - entity: living room speaker
+            - Give me  status of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  status of the living room speaker:
+                    - entity: living room speaker
+            - Give me  status of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  status of  living room speaker:
+                    - entity: living room speaker
+            - Give me  read out of my living room speaker please:
+                    - entity: living room speaker
+            - Give me  read out of my living room speaker:
+                    - entity: living room speaker
+            - Give me  read out of the living room speaker please:
+                    - entity: living room speaker
+            - Give me  read out of the living room speaker:
+                    - entity: living room speaker
+            - Give me  read out of  living room speaker please:
+                    - entity: living room speaker
+            - Give me  read out of  living room speaker:
+                    - entity: living room speaker
+            - Give me the temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the temperature of my living room speaker:
+                    - entity: living room speaker
+            - Give me the temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the temperature of the living room speaker:
+                    - entity: living room speaker
+            - Give me the temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the temperature of  living room speaker:
+                    - entity: living room speaker
+            - Give me the hue of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the hue of my living room speaker:
+                    - entity: living room speaker
+            - Give me the hue of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the hue of the living room speaker:
+                    - entity: living room speaker
+            - Give me the hue of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the hue of  living room speaker:
+                    - entity: living room speaker
+            - Give me the value of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the value of my living room speaker:
+                    - entity: living room speaker
+            - Give me the value of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the value of the living room speaker:
+                    - entity: living room speaker
+            - Give me the value of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the value of  living room speaker:
+                    - entity: living room speaker
+            - Give me the state of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the state of my living room speaker:
+                    - entity: living room speaker
+            - Give me the state of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the state of the living room speaker:
+                    - entity: living room speaker
+            - Give me the state of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the state of  living room speaker:
+                    - entity: living room speaker
+            - Give me the status of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the status of my living room speaker:
+                    - entity: living room speaker
+            - Give me the status of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the status of the living room speaker:
+                    - entity: living room speaker
+            - Give me the status of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the status of  living room speaker:
+                    - entity: living room speaker
+            - Give me the read out of my living room speaker please:
+                    - entity: living room speaker
+            - Give me the read out of my living room speaker:
+                    - entity: living room speaker
+            - Give me the read out of the living room speaker please:
+                    - entity: living room speaker
+            - Give me the read out of the living room speaker:
+                    - entity: living room speaker
+            - Give me the read out of  living room speaker please:
+                    - entity: living room speaker
+            - Give me the read out of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  temperature of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  temperature of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  temperature of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  hue of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  hue of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  hue of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  hue of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  hue of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  hue of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  value of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  value of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  value of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  value of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  value of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  value of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  state of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  state of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  state of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  state of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  state of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  state of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  status of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  status of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  status of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  status of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  status of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  status of  living room speaker:
+                    - entity: living room speaker
+            - Tell me  read out of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me  read out of my living room speaker:
+                    - entity: living room speaker
+            - Tell me  read out of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me  read out of the living room speaker:
+                    - entity: living room speaker
+            - Tell me  read out of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me  read out of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the temperature of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the temperature of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the temperature of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the hue of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the hue of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the hue of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the hue of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the hue of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the hue of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the value of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the value of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the value of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the value of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the value of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the value of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the state of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the state of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the state of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the state of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the state of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the state of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the status of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the status of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the status of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the status of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the status of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the status of  living room speaker:
+                    - entity: living room speaker
+            - Tell me the read out of my living room speaker please:
+                    - entity: living room speaker
+            - Tell me the read out of my living room speaker:
+                    - entity: living room speaker
+            - Tell me the read out of the living room speaker please:
+                    - entity: living room speaker
+            - Tell me the read out of the living room speaker:
+                    - entity: living room speaker
+            - Tell me the read out of  living room speaker please:
+                    - entity: living room speaker
+            - Tell me the read out of  living room speaker:
+                    - entity: living room speaker
+            - Get  temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Get  temperature of my living room speaker:
+                    - entity: living room speaker
+            - Get  temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Get  temperature of the living room speaker:
+                    - entity: living room speaker
+            - Get  temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Get  temperature of  living room speaker:
+                    - entity: living room speaker
+            - Get  hue of my living room speaker please:
+                    - entity: living room speaker
+            - Get  hue of my living room speaker:
+                    - entity: living room speaker
+            - Get  hue of the living room speaker please:
+                    - entity: living room speaker
+            - Get  hue of the living room speaker:
+                    - entity: living room speaker
+            - Get  hue of  living room speaker please:
+                    - entity: living room speaker
+            - Get  hue of  living room speaker:
+                    - entity: living room speaker
+            - Get  value of my living room speaker please:
+                    - entity: living room speaker
+            - Get  value of my living room speaker:
+                    - entity: living room speaker
+            - Get  value of the living room speaker please:
+                    - entity: living room speaker
+            - Get  value of the living room speaker:
+                    - entity: living room speaker
+            - Get  value of  living room speaker please:
+                    - entity: living room speaker
+            - Get  value of  living room speaker:
+                    - entity: living room speaker
+            - Get  state of my living room speaker please:
+                    - entity: living room speaker
+            - Get  state of my living room speaker:
+                    - entity: living room speaker
+            - Get  state of the living room speaker please:
+                    - entity: living room speaker
+            - Get  state of the living room speaker:
+                    - entity: living room speaker
+            - Get  state of  living room speaker please:
+                    - entity: living room speaker
+            - Get  state of  living room speaker:
+                    - entity: living room speaker
+            - Get  status of my living room speaker please:
+                    - entity: living room speaker
+            - Get  status of my living room speaker:
+                    - entity: living room speaker
+            - Get  status of the living room speaker please:
+                    - entity: living room speaker
+            - Get  status of the living room speaker:
+                    - entity: living room speaker
+            - Get  status of  living room speaker please:
+                    - entity: living room speaker
+            - Get  status of  living room speaker:
+                    - entity: living room speaker
+            - Get  read out of my living room speaker please:
+                    - entity: living room speaker
+            - Get  read out of my living room speaker:
+                    - entity: living room speaker
+            - Get  read out of the living room speaker please:
+                    - entity: living room speaker
+            - Get  read out of the living room speaker:
+                    - entity: living room speaker
+            - Get  read out of  living room speaker please:
+                    - entity: living room speaker
+            - Get  read out of  living room speaker:
+                    - entity: living room speaker
+            - Get the temperature of my living room speaker please:
+                    - entity: living room speaker
+            - Get the temperature of my living room speaker:
+                    - entity: living room speaker
+            - Get the temperature of the living room speaker please:
+                    - entity: living room speaker
+            - Get the temperature of the living room speaker:
+                    - entity: living room speaker
+            - Get the temperature of  living room speaker please:
+                    - entity: living room speaker
+            - Get the temperature of  living room speaker:
+                    - entity: living room speaker
+            - Get the hue of my living room speaker please:
+                    - entity: living room speaker
+            - Get the hue of my living room speaker:
+                    - entity: living room speaker
+            - Get the hue of the living room speaker please:
+                    - entity: living room speaker
+            - Get the hue of the living room speaker:
+                    - entity: living room speaker
+            - Get the hue of  living room speaker please:
+                    - entity: living room speaker
+            - Get the hue of  living room speaker:
+                    - entity: living room speaker
+            - Get the value of my living room speaker please:
+                    - entity: living room speaker
+            - Get the value of my living room speaker:
+                    - entity: living room speaker
+            - Get the value of the living room speaker please:
+                    - entity: living room speaker
+            - Get the value of the living room speaker:
+                    - entity: living room speaker
+            - Get the value of  living room speaker please:
+                    - entity: living room speaker
+            - Get the value of  living room speaker:
+                    - entity: living room speaker
+            - Get the state of my living room speaker please:
+                    - entity: living room speaker
+            - Get the state of my living room speaker:
+                    - entity: living room speaker
+            - Get the state of the living room speaker please:
+                    - entity: living room speaker
+            - Get the state of the living room speaker:
+                    - entity: living room speaker
+            - Get the state of  living room speaker please:
+                    - entity: living room speaker
+            - Get the state of  living room speaker:
+                    - entity: living room speaker
+            - Get the status of my living room speaker please:
+                    - entity: living room speaker
+            - Get the status of my living room speaker:
+                    - entity: living room speaker
+            - Get the status of the living room speaker please:
+                    - entity: living room speaker
+            - Get the status of the living room speaker:
+                    - entity: living room speaker
+            - Get the status of  living room speaker please:
+                    - entity: living room speaker
+            - Get the status of  living room speaker:
+                    - entity: living room speaker
+            - Get the read out of my living room speaker please:
+                    - entity: living room speaker
+            - Get the read out of my living room speaker:
+                    - entity: living room speaker
+            - Get the read out of the living room speaker please:
+                    - entity: living room speaker
+            - Get the read out of the living room speaker:
+                    - entity: living room speaker
+            - Get the read out of  living room speaker please:
+                    - entity: living room speaker
+            - Get the read out of  living room speaker:
+                    - entity: living room speaker
+            - is my living room speaker on:
+                    - entity: living room speaker
+            - is my living room speaker off:
+                    - entity: living room speaker
+            - is my living room speaker high:
+                    - entity: living room speaker
+            - is my living room speaker low:
+                    - entity: living room speaker
+            - is my living room speaker cold:
+                    - entity: living room speaker
+            - is my living room speaker warm:
+                    - entity: living room speaker
+            - is my living room speaker hot:
+                    - entity: living room speaker
+            - is my living room speaker connected:
+                    - entity: living room speaker
+            - is my living room speaker disconnected:
+                    - entity: living room speaker
+            - is my living room speaker open:
+                    - entity: living room speaker
+            - is my living room speaker closed:
+                    - entity: living room speaker
+            - is my living room speaker dark:
+                    - entity: living room speaker
+            - is my living room speaker in motion:
+                    - entity: living room speaker
+            - is my living room speaker occupied:
+                    - entity: living room speaker
+            - is my living room speaker plugged in:
+                    - entity: living room speaker
+            - is my living room speaker secure:
+                    - entity: living room speaker
+            - is my living room speaker unsecure:
+                    - entity: living room speaker
+            - is my living room speaker charging:
+                    - entity: living room speaker
+            - is my living room speaker available:
+                    - entity: living room speaker
+            - is the living room speaker on:
+                    - entity: living room speaker
+            - is the living room speaker off:
+                    - entity: living room speaker
+            - is the living room speaker high:
+                    - entity: living room speaker
+            - is the living room speaker low:
+                    - entity: living room speaker
+            - is the living room speaker cold:
+                    - entity: living room speaker
+            - is the living room speaker warm:
+                    - entity: living room speaker
+            - is the living room speaker hot:
+                    - entity: living room speaker
+            - is the living room speaker connected:
+                    - entity: living room speaker
+            - is the living room speaker disconnected:
+                    - entity: living room speaker
+            - is the living room speaker open:
+                    - entity: living room speaker
+            - is the living room speaker closed:
+                    - entity: living room speaker
+            - is the living room speaker dark:
+                    - entity: living room speaker
+            - is the living room speaker in motion:
+                    - entity: living room speaker
+            - is the living room speaker occupied:
+                    - entity: living room speaker
+            - is the living room speaker plugged in:
+                    - entity: living room speaker
+            - is the living room speaker secure:
+                    - entity: living room speaker
+            - is the living room speaker unsecure:
+                    - entity: living room speaker
+            - is the living room speaker charging:
+                    - entity: living room speaker
+            - is the living room speaker available:
+                    - entity: living room speaker
+            - is  living room speaker on:
+                    - entity: living room speaker
+            - is  living room speaker off:
+                    - entity: living room speaker
+            - is  living room speaker high:
+                    - entity: living room speaker
+            - is  living room speaker low:
+                    - entity: living room speaker
+            - is  living room speaker cold:
+                    - entity: living room speaker
+            - is  living room speaker warm:
+                    - entity: living room speaker
+            - is  living room speaker hot:
+                    - entity: living room speaker
+            - is  living room speaker connected:
+                    - entity: living room speaker
+            - is  living room speaker disconnected:
+                    - entity: living room speaker
+            - is  living room speaker open:
+                    - entity: living room speaker
+            - is  living room speaker closed:
+                    - entity: living room speaker
+            - is  living room speaker dark:
+                    - entity: living room speaker
+            - is  living room speaker in motion:
+                    - entity: living room speaker
+            - is  living room speaker occupied:
+                    - entity: living room speaker
+            - is  living room speaker plugged in:
+                    - entity: living room speaker
+            - is  living room speaker secure:
+                    - entity: living room speaker
+            - is  living room speaker unsecure:
+                    - entity: living room speaker
+            - is  living room speaker charging:
+                    - entity: living room speaker
+            - is  living room speaker available:
+                    - entity: living room speaker
+            - has  living room speaker detected a moisture:
+                    - entity: living room speaker
+            - has  living room speaker detected a energy:
+                    - entity: living room speaker
+            - has  living room speaker detected a problem:
+                    - entity: living room speaker
+            - has  living room speaker detected a vibration:
+                    - entity: living room speaker
+            - has  living room speaker detected a gas:
+                    - entity: living room speaker
+            - has  living room speaker detected a sound:
+                    - entity: living room speaker
+            - has  living room speaker detected  moisture:
+                    - entity: living room speaker
+            - has  living room speaker detected  energy:
+                    - entity: living room speaker
+            - has  living room speaker detected  problem:
+                    - entity: living room speaker
+            - has  living room speaker detected  vibration:
+                    - entity: living room speaker
+            - has  living room speaker detected  gas:
+                    - entity: living room speaker
+            - has  living room speaker detected  sound:
+                    - entity: living room speaker
+            - has the living room speaker detected a moisture:
+                    - entity: living room speaker
+            - has the living room speaker detected a energy:
+                    - entity: living room speaker
+            - has the living room speaker detected a problem:
+                    - entity: living room speaker
+            - has the living room speaker detected a vibration:
+                    - entity: living room speaker
+            - has the living room speaker detected a gas:
+                    - entity: living room speaker
+            - has the living room speaker detected a sound:
+                    - entity: living room speaker
+            - has the living room speaker detected  moisture:
+                    - entity: living room speaker
+            - has the living room speaker detected  energy:
+                    - entity: living room speaker
+            - has the living room speaker detected  problem:
+                    - entity: living room speaker
+            - has the living room speaker detected  vibration:
+                    - entity: living room speaker
+            - has the living room speaker detected  gas:
+                    - entity: living room speaker
+            - has the living room speaker detected  sound:
+                    - entity: living room speaker
+            - has my living room speaker detected a moisture:
+                    - entity: living room speaker
+            - has my living room speaker detected a energy:
+                    - entity: living room speaker
+            - has my living room speaker detected a problem:
+                    - entity: living room speaker
+            - has my living room speaker detected a vibration:
+                    - entity: living room speaker
+            - has my living room speaker detected a gas:
+                    - entity: living room speaker
+            - has my living room speaker detected a sound:
+                    - entity: living room speaker
+            - has my living room speaker detected  moisture:
+                    - entity: living room speaker
+            - has my living room speaker detected  energy:
+                    - entity: living room speaker
+            - has my living room speaker detected  problem:
+                    - entity: living room speaker
+            - has my living room speaker detected  vibration:
+                    - entity: living room speaker
+            - has my living room speaker detected  gas:
+                    - entity: living room speaker
+            - has my living room speaker detected  sound:
+                    - entity: living room speaker
 
-    lights.decrease.brightness.intent:
-        - decrease the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - decrease the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - decrease the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - decrease the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - decrease the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - decrease the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - decrease  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - make  bedside lamp dimmer:
-              - entity: bedside lamp
-        - make the bedside lamp dimmer:
-              - entity: bedside lamp
-        - make my bedside lamp dimmer:
-              - entity: bedside lamp
-        - dim down the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - dim down the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - dim down the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - dim down the brightness  my bedside lamp:
-              - entity: bedside lamp
-        - dim down the brightness  the bedside lamp:
-              - entity: bedside lamp
-        - dim down the brightness   bedside lamp:
-              - entity: bedside lamp
-        - dim down the  of my bedside lamp:
-              - entity: bedside lamp
-        - dim down the  of the bedside lamp:
-              - entity: bedside lamp
-        - dim down the  of  bedside lamp:
-              - entity: bedside lamp
-        - dim down the   my bedside lamp:
-              - entity: bedside lamp
-        - dim down the   the bedside lamp:
-              - entity: bedside lamp
-        - dim down the    bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness  my bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness  the bedside lamp:
-              - entity: bedside lamp
-        - dim down  brightness   bedside lamp:
-              - entity: bedside lamp
-        - dim down   of my bedside lamp:
-              - entity: bedside lamp
-        - dim down   of the bedside lamp:
-              - entity: bedside lamp
-        - dim down   of  bedside lamp:
-              - entity: bedside lamp
-        - dim down    my bedside lamp:
-              - entity: bedside lamp
-        - dim down    the bedside lamp:
-              - entity: bedside lamp
-        - dim down     bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness  my bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness  the bedside lamp:
-              - entity: bedside lamp
-        - dim  the brightness   bedside lamp:
-              - entity: bedside lamp
-        - dim  the  of my bedside lamp:
-              - entity: bedside lamp
-        - dim  the  of the bedside lamp:
-              - entity: bedside lamp
-        - dim  the  of  bedside lamp:
-              - entity: bedside lamp
-        - dim  the   my bedside lamp:
-              - entity: bedside lamp
-        - dim  the   the bedside lamp:
-              - entity: bedside lamp
-        - dim  the    bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness of my bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness of the bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness of  bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness  my bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness  the bedside lamp:
-              - entity: bedside lamp
-        - dim   brightness   bedside lamp:
-              - entity: bedside lamp
-        - dim    of my bedside lamp:
-              - entity: bedside lamp
-        - dim    of the bedside lamp:
-              - entity: bedside lamp
-        - dim    of  bedside lamp:
-              - entity: bedside lamp
-        - dim     my bedside lamp:
-              - entity: bedside lamp
-        - dim     the bedside lamp:
-              - entity: bedside lamp
-        - dim      bedside lamp:
-              - entity: bedside lamp
+      lights.decrease.brightness.intent:
+            - decrease the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - decrease the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - decrease the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - decrease the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - decrease the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - decrease the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - decrease  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - make  bedside lamp dimmer:
+                    - entity: bedside lamp
+            - make the bedside lamp dimmer:
+                    - entity: bedside lamp
+            - make my bedside lamp dimmer:
+                    - entity: bedside lamp
+            - dim down the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - dim down the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - dim down the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - dim down the brightness  my bedside lamp:
+                    - entity: bedside lamp
+            - dim down the brightness  the bedside lamp:
+                    - entity: bedside lamp
+            - dim down the brightness   bedside lamp:
+                    - entity: bedside lamp
+            - dim down the  of my bedside lamp:
+                    - entity: bedside lamp
+            - dim down the  of the bedside lamp:
+                    - entity: bedside lamp
+            - dim down the  of  bedside lamp:
+                    - entity: bedside lamp
+            - dim down the   my bedside lamp:
+                    - entity: bedside lamp
+            - dim down the   the bedside lamp:
+                    - entity: bedside lamp
+            - dim down the    bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness  my bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness  the bedside lamp:
+                    - entity: bedside lamp
+            - dim down  brightness   bedside lamp:
+                    - entity: bedside lamp
+            - dim down   of my bedside lamp:
+                    - entity: bedside lamp
+            - dim down   of the bedside lamp:
+                    - entity: bedside lamp
+            - dim down   of  bedside lamp:
+                    - entity: bedside lamp
+            - dim down    my bedside lamp:
+                    - entity: bedside lamp
+            - dim down    the bedside lamp:
+                    - entity: bedside lamp
+            - dim down     bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness  my bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness  the bedside lamp:
+                    - entity: bedside lamp
+            - dim  the brightness   bedside lamp:
+                    - entity: bedside lamp
+            - dim  the  of my bedside lamp:
+                    - entity: bedside lamp
+            - dim  the  of the bedside lamp:
+                    - entity: bedside lamp
+            - dim  the  of  bedside lamp:
+                    - entity: bedside lamp
+            - dim  the   my bedside lamp:
+                    - entity: bedside lamp
+            - dim  the   the bedside lamp:
+                    - entity: bedside lamp
+            - dim  the    bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness  my bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness  the bedside lamp:
+                    - entity: bedside lamp
+            - dim   brightness   bedside lamp:
+                    - entity: bedside lamp
+            - dim    of my bedside lamp:
+                    - entity: bedside lamp
+            - dim    of the bedside lamp:
+                    - entity: bedside lamp
+            - dim    of  bedside lamp:
+                    - entity: bedside lamp
+            - dim     my bedside lamp:
+                    - entity: bedside lamp
+            - dim     the bedside lamp:
+                    - entity: bedside lamp
+            - dim      bedside lamp:
+                    - entity: bedside lamp
 
-    lights.increase.brightness.intent:
-        - increase the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - increase the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - increase the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - increase  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - increase  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - increase  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - make  bedside lamp brighter:
-              - entity: bedside lamp
-        - make the bedside lamp brighter:
-              - entity: bedside lamp
-        - make my bedside lamp brighter:
-              - entity: bedside lamp
-        - bump up the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - bump up the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - bump up the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - bump up  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - bump up  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - bump up  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - bump  the brightness of my bedside lamp:
-              - entity: bedside lamp
-        - bump  the brightness of the bedside lamp:
-              - entity: bedside lamp
-        - bump  the brightness of  bedside lamp:
-              - entity: bedside lamp
-        - bump   brightness of my bedside lamp:
-              - entity: bedside lamp
-        - bump   brightness of the bedside lamp:
-              - entity: bedside lamp
-        - bump   brightness of  bedside lamp:
-              - entity: bedside lamp
+      lights.increase.brightness.intent:
+            - increase the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - increase the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - increase the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - increase  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - increase  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - increase  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - make  bedside lamp brighter:
+                    - entity: bedside lamp
+            - make the bedside lamp brighter:
+                    - entity: bedside lamp
+            - make my bedside lamp brighter:
+                    - entity: bedside lamp
+            - bump up the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - bump up the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - bump up the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - bump up  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - bump up  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - bump up  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - bump  the brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - bump  the brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - bump  the brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - bump   brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - bump   brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - bump   brightness of  bedside lamp:
+                    - entity: bedside lamp
 
-    lights.get.brightness.intent:
-        - query the current brightness of my bedside lamp:
-              - entity: bedside lamp
-        - query the current brightness of the bedside lamp:
-              - entity: bedside lamp
-        - query the current brightness of  bedside lamp:
-              - entity: bedside lamp
-        - query the  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - query the  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - query the  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - get the current brightness of my bedside lamp:
-              - entity: bedside lamp
-        - get the current brightness of the bedside lamp:
-              - entity: bedside lamp
-        - get the current brightness of  bedside lamp:
-              - entity: bedside lamp
-        - get the  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - get the  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - get the  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - what's the current brightness of my bedside lamp:
-              - entity: bedside lamp
-        - what's the current brightness of the bedside lamp:
-              - entity: bedside lamp
-        - what's the current brightness of  bedside lamp:
-              - entity: bedside lamp
-        - what's the  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - what's the  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - what's the  brightness of  bedside lamp:
-              - entity: bedside lamp
-        - what is the current brightness of my bedside lamp:
-              - entity: bedside lamp
-        - what is the current brightness of the bedside lamp:
-              - entity: bedside lamp
-        - what is the current brightness of  bedside lamp:
-              - entity: bedside lamp
-        - what is the  brightness of my bedside lamp:
-              - entity: bedside lamp
-        - what is the  brightness of the bedside lamp:
-              - entity: bedside lamp
-        - what is the  brightness of  bedside lamp:
-              - entity: bedside lamp
+      lights.get.brightness.intent:
+            - query the current brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - query the current brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - query the current brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - query the  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - query the  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - query the  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - get the current brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - get the current brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - get the current brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - get the  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - get the  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - get the  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - what's the current brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - what's the current brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - what's the current brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - what's the  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - what's the  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - what's the  brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - what is the current brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - what is the current brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - what is the current brightness of  bedside lamp:
+                    - entity: bedside lamp
+            - what is the  brightness of my bedside lamp:
+                    - entity: bedside lamp
+            - what is the  brightness of the bedside lamp:
+                    - entity: bedside lamp
+            - what is the  brightness of  bedside lamp:
+                    - entity: bedside lamp
 
-    lights.set.brightness.intent:
-        - change the brightness of my lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change the brightness of my lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - change the brightness of the lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change the brightness of the lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - change the brightness of lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change the brightness of lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of my lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of my lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of the lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of the lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - change brightness of lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of my lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of my lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of the lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of the lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set the brightness of lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of my lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of my lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of the lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of the lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of lamp to one hundred:
-              - entity: lamp
-              - brightness: one hundred
-        - set brightness of lamp to one hundred percent:
-              - entity: lamp
-              - brightness: one hundred
+      lights.set.brightness.intent:
+            - change the brightness of my lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change the brightness of my lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change the brightness of the lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change the brightness of the lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change the brightness of lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change the brightness of lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of my lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of my lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of the lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of the lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - change brightness of lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of my lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of my lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of the lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of the lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set the brightness of lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of my lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of my lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of the lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of the lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of lamp to one hundred:
+                    - entity: lamp
+                    - brightness: one hundred
+            - set brightness of lamp to one hundred percent:
+                    - entity: lamp
+                    - brightness: one hundred
 
-    lights.get.color.intent:
-        - get   color of my bedside lamp:
-              - entity: bedside lamp
-        - get   color of the bedside lamp:
-              - entity: bedside lamp
-        - get   color of  bedside lamp:
-              - entity: bedside lamp
-        - get  current color of my bedside lamp:
-              - entity: bedside lamp
-        - get  current color of the bedside lamp:
-              - entity: bedside lamp
-        - get  current color of  bedside lamp:
-              - entity: bedside lamp
-        - get the  color of my bedside lamp:
-              - entity: bedside lamp
-        - get the  color of the bedside lamp:
-              - entity: bedside lamp
-        - get the  color of  bedside lamp:
-              - entity: bedside lamp
-        - get the current color of my bedside lamp:
-              - entity: bedside lamp
-        - get the current color of the bedside lamp:
-              - entity: bedside lamp
-        - get the current color of  bedside lamp:
-              - entity: bedside lamp
-        - query   color of my bedside lamp:
-              - entity: bedside lamp
-        - query   color of the bedside lamp:
-              - entity: bedside lamp
-        - query   color of  bedside lamp:
-              - entity: bedside lamp
-        - query  current color of my bedside lamp:
-              - entity: bedside lamp
-        - query  current color of the bedside lamp:
-              - entity: bedside lamp
-        - query  current color of  bedside lamp:
-              - entity: bedside lamp
-        - query the  color of my bedside lamp:
-              - entity: bedside lamp
-        - query the  color of the bedside lamp:
-              - entity: bedside lamp
-        - query the  color of  bedside lamp:
-              - entity: bedside lamp
-        - query the current color of my bedside lamp:
-              - entity: bedside lamp
-        - query the current color of the bedside lamp:
-              - entity: bedside lamp
-        - query the current color of  bedside lamp:
-              - entity: bedside lamp
-        - what is   color of my bedside lamp:
-              - entity: bedside lamp
-        - what is   color of the bedside lamp:
-              - entity: bedside lamp
-        - what is   color of  bedside lamp:
-              - entity: bedside lamp
-        - what is  current color of my bedside lamp:
-              - entity: bedside lamp
-        - what is  current color of the bedside lamp:
-              - entity: bedside lamp
-        - what is  current color of  bedside lamp:
-              - entity: bedside lamp
-        - what is the  color of my bedside lamp:
-              - entity: bedside lamp
-        - what is the  color of the bedside lamp:
-              - entity: bedside lamp
-        - what is the  color of  bedside lamp:
-              - entity: bedside lamp
-        - what is the current color of my bedside lamp:
-              - entity: bedside lamp
-        - what is the current color of the bedside lamp:
-              - entity: bedside lamp
-        - what is the current color of  bedside lamp:
-              - entity: bedside lamp
-        - what's   color of my bedside lamp:
-              - entity: bedside lamp
-        - what's   color of the bedside lamp:
-              - entity: bedside lamp
-        - what's   color of  bedside lamp:
-              - entity: bedside lamp
-        - what's  current color of my bedside lamp:
-              - entity: bedside lamp
-        - what's  current color of the bedside lamp:
-              - entity: bedside lamp
-        - what's  current color of  bedside lamp:
-              - entity: bedside lamp
-        - what's the  color of my bedside lamp:
-              - entity: bedside lamp
-        - what's the  color of the bedside lamp:
-              - entity: bedside lamp
-        - what's the  color of  bedside lamp:
-              - entity: bedside lamp
-        - what's the current color of my bedside lamp:
-              - entity: bedside lamp
-        - what's the current color of the bedside lamp:
-              - entity: bedside lamp
-        - what's the current color of  bedside lamp:
-              - entity: bedside lamp
+      lights.get.color.intent:
+            - get   color of my bedside lamp:
+                    - entity: bedside lamp
+            - get   color of the bedside lamp:
+                    - entity: bedside lamp
+            - get   color of  bedside lamp:
+                    - entity: bedside lamp
+            - get  current color of my bedside lamp:
+                    - entity: bedside lamp
+            - get  current color of the bedside lamp:
+                    - entity: bedside lamp
+            - get  current color of  bedside lamp:
+                    - entity: bedside lamp
+            - get the  color of my bedside lamp:
+                    - entity: bedside lamp
+            - get the  color of the bedside lamp:
+                    - entity: bedside lamp
+            - get the  color of  bedside lamp:
+                    - entity: bedside lamp
+            - get the current color of my bedside lamp:
+                    - entity: bedside lamp
+            - get the current color of the bedside lamp:
+                    - entity: bedside lamp
+            - get the current color of  bedside lamp:
+                    - entity: bedside lamp
+            - query   color of my bedside lamp:
+                    - entity: bedside lamp
+            - query   color of the bedside lamp:
+                    - entity: bedside lamp
+            - query   color of  bedside lamp:
+                    - entity: bedside lamp
+            - query  current color of my bedside lamp:
+                    - entity: bedside lamp
+            - query  current color of the bedside lamp:
+                    - entity: bedside lamp
+            - query  current color of  bedside lamp:
+                    - entity: bedside lamp
+            - query the  color of my bedside lamp:
+                    - entity: bedside lamp
+            - query the  color of the bedside lamp:
+                    - entity: bedside lamp
+            - query the  color of  bedside lamp:
+                    - entity: bedside lamp
+            - query the current color of my bedside lamp:
+                    - entity: bedside lamp
+            - query the current color of the bedside lamp:
+                    - entity: bedside lamp
+            - query the current color of  bedside lamp:
+                    - entity: bedside lamp
+            - what is   color of my bedside lamp:
+                    - entity: bedside lamp
+            - what is   color of the bedside lamp:
+                    - entity: bedside lamp
+            - what is   color of  bedside lamp:
+                    - entity: bedside lamp
+            - what is  current color of my bedside lamp:
+                    - entity: bedside lamp
+            - what is  current color of the bedside lamp:
+                    - entity: bedside lamp
+            - what is  current color of  bedside lamp:
+                    - entity: bedside lamp
+            - what is the  color of my bedside lamp:
+                    - entity: bedside lamp
+            - what is the  color of the bedside lamp:
+                    - entity: bedside lamp
+            - what is the  color of  bedside lamp:
+                    - entity: bedside lamp
+            - what is the current color of my bedside lamp:
+                    - entity: bedside lamp
+            - what is the current color of the bedside lamp:
+                    - entity: bedside lamp
+            - what is the current color of  bedside lamp:
+                    - entity: bedside lamp
+            - what's   color of my bedside lamp:
+                    - entity: bedside lamp
+            - what's   color of the bedside lamp:
+                    - entity: bedside lamp
+            - what's   color of  bedside lamp:
+                    - entity: bedside lamp
+            - what's  current color of my bedside lamp:
+                    - entity: bedside lamp
+            - what's  current color of the bedside lamp:
+                    - entity: bedside lamp
+            - what's  current color of  bedside lamp:
+                    - entity: bedside lamp
+            - what's the  color of my bedside lamp:
+                    - entity: bedside lamp
+            - what's the  color of the bedside lamp:
+                    - entity: bedside lamp
+            - what's the  color of  bedside lamp:
+                    - entity: bedside lamp
+            - what's the current color of my bedside lamp:
+                    - entity: bedside lamp
+            - what's the current color of the bedside lamp:
+                    - entity: bedside lamp
+            - what's the current color of  bedside lamp:
+                    - entity: bedside lamp
 
-    lights.set.color.intent:
-        - adjust bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - adjust the bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - adjust my bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make the bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make my bedside lamp color to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make my light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make the light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
-        - make light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
-        - change my light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
-        - change the light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
-        - change light bedside lamp to blue:
-              - entity: bedside lamp
-              - color: blue
+      lights.set.color.intent:
+            - adjust bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - adjust the bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - adjust my bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make the bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make my bedside lamp color to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make my light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make the light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - make light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - change my light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - change the light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
+            - change light bedside lamp to blue:
+                    - entity: bedside lamp
+                    - color: blue
 
-    show_area_dashboard.intent:
-        - open living room dashboard:
-              - area: living room
-        - display living room dashboard:
-              - area: living room
-        - open the living room dashboard:
-              - area: living room
-        - display the living room dashboard:
-              - area: living room
-        - open my living room dashboard:
-              - area: living room
-        - display my living room dashboard:
-              - area: living room
-        - open living room:
-              - area: living room
-        - display living room:
-              - area: living room
-        - open the living room:
-              - area: living room
-        - display the living room:
-              - area: living room
-        - open my living room:
-              - area: living room
-        - display my living room:
-              - area: living room
+      show_area_dashboard.intent:
+            - open living room dashboard:
+                    - area: living room
+            - display living room dashboard:
+                    - area: living room
+            - open the living room dashboard:
+                    - area: living room
+            - display the living room dashboard:
+                    - area: living room
+            - open my living room dashboard:
+                    - area: living room
+            - display my living room dashboard:
+                    - area: living room
+            - open living room:
+                    - area: living room
+            - display living room:
+                    - area: living room
+            - open the living room:
+                    - area: living room
+            - display the living room:
+                    - area: living room
+            - open my living room:
+                    - area: living room
+            - display my living room:
+                    - area: living room
 
-    turn_off.intent:
-        - turn off my living room speaker:
-              - entity: living room speaker
-        - turn off the living room speaker:
-              - entity: living room speaker
-        - turn off  living room speaker:
-              - entity: living room speaker
-        - turn my living room speaker off:
-              - entity: living room speaker
-        - turn the living room speaker off:
-              - entity: living room speaker
-        - turn  living room speaker off:
-              - entity: living room speaker
-        - Can you turn  my living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn  my living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn  the living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn  the living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn   living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn   living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn off my living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn off my living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn off the living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn off the living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn off  living room speaker off please?:
-              - entity: living room speaker
-        - Can you turn off  living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn  my living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn  my living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn  the living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn  the living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn   living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn   living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn off my living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn off my living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn off the living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn off the living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn off  living room speaker off please?:
-              - entity: living room speaker
-        - Would you turn off  living room speaker  please?:
-              - entity: living room speaker
-        - I'd like to turn  my living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn  my living room speaker:
-              - entity: living room speaker
-        - I'd like to turn  the living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn  the living room speaker:
-              - entity: living room speaker
-        - I'd like to turn   living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn   living room speaker:
-              - entity: living room speaker
-        - I'd like to turn off my living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn off my living room speaker:
-              - entity: living room speaker
-        - I'd like to turn off the living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn off the living room speaker:
-              - entity: living room speaker
-        - I'd like to turn off  living room speaker off:
-              - entity: living room speaker
-        - I'd like to turn off  living room speaker:
-              - entity: living room speaker
-        - I would like my living room speaker off:
-              - entity: living room speaker
-        - I would like the living room speaker off:
-              - entity: living room speaker
-        - I would like  living room speaker off:
-              - entity: living room speaker
+      turn_off.intent:
+            - turn off my living room speaker:
+                    - entity: living room speaker
+            - turn off the living room speaker:
+                    - entity: living room speaker
+            - turn off  living room speaker:
+                    - entity: living room speaker
+            - turn my living room speaker off:
+                    - entity: living room speaker
+            - turn the living room speaker off:
+                    - entity: living room speaker
+            - turn  living room speaker off:
+                    - entity: living room speaker
+            - Can you turn  my living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn  my living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn  the living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn  the living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn   living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn   living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn off my living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn off my living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn off the living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn off the living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn off  living room speaker off please?:
+                    - entity: living room speaker
+            - Can you turn off  living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn  my living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn  my living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn  the living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn  the living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn   living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn   living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn off my living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn off my living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn off the living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn off the living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn off  living room speaker off please?:
+                    - entity: living room speaker
+            - Would you turn off  living room speaker  please?:
+                    - entity: living room speaker
+            - I'd like to turn  my living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn  my living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn  the living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn  the living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn   living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn   living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn off my living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn off my living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn off the living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn off the living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn off  living room speaker off:
+                    - entity: living room speaker
+            - I'd like to turn off  living room speaker:
+                    - entity: living room speaker
+            - I would like my living room speaker off:
+                    - entity: living room speaker
+            - I would like the living room speaker off:
+                    - entity: living room speaker
+            - I would like  living room speaker off:
+                    - entity: living room speaker
 
-    turn_on.intent:
-        - turn on my living room speaker:
-              - entity: living room speaker
-        - turn on the living room speaker:
-              - entity: living room speaker
-        - turn on  living room speaker:
-              - entity: living room speaker
-        - turn  living room speaker on:
-              - entity: living room speaker
-        - turn the living room speaker on:
-              - entity: living room speaker
-        - turn my living room speaker on:
-              - entity: living room speaker
-        - Can you turn  my living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn  my living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn  the living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn  the living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn   living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn   living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn on my living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn on my living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn on the living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn on the living room speaker  please?:
-              - entity: living room speaker
-        - Can you turn on  living room speaker on please?:
-              - entity: living room speaker
-        - Can you turn on  living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn  my living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn  my living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn  the living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn  the living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn   living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn   living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn on my living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn on my living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn on the living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn on the living room speaker  please?:
-              - entity: living room speaker
-        - Would you turn on  living room speaker on please?:
-              - entity: living room speaker
-        - Would you turn on  living room speaker  please?:
-              - entity: living room speaker
-        - I'd like to turn  my living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn  my living room speaker:
-              - entity: living room speaker
-        - I'd like to turn  the living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn  the living room speaker:
-              - entity: living room speaker
-        - I'd like to turn   living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn   living room speaker:
-              - entity: living room speaker
-        - I'd like to turn on my living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn on my living room speaker:
-              - entity: living room speaker
-        - I'd like to turn on the living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn on the living room speaker:
-              - entity: living room speaker
-        - I'd like to turn on  living room speaker on:
-              - entity: living room speaker
-        - I'd like to turn on  living room speaker:
-              - entity: living room speaker
-        - I would like  living room speaker on:
-              - entity: living room speaker
-        - I would like the living room speaker on:
-              - entity: living room speaker
-        - I would like my living room speaker on:
-              - entity: living room speaker
-    assist.intent:
-        - tell home assistant to turn on the roomba
-              - command: turn on the roomba
-        - tell home assistant turn on the roomba
-              - command: turn on the roomba
-
+      turn_on.intent:
+            - turn on my living room speaker:
+                    - entity: living room speaker
+            - turn on the living room speaker:
+                    - entity: living room speaker
+            - turn on  living room speaker:
+                    - entity: living room speaker
+            - turn  living room speaker on:
+                    - entity: living room speaker
+            - turn the living room speaker on:
+                    - entity: living room speaker
+            - turn my living room speaker on:
+                    - entity: living room speaker
+            - Can you turn  my living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn  my living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn  the living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn  the living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn   living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn   living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn on my living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn on my living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn on the living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn on the living room speaker  please?:
+                    - entity: living room speaker
+            - Can you turn on  living room speaker on please?:
+                    - entity: living room speaker
+            - Can you turn on  living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn  my living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn  my living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn  the living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn  the living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn   living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn   living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn on my living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn on my living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn on the living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn on the living room speaker  please?:
+                    - entity: living room speaker
+            - Would you turn on  living room speaker on please?:
+                    - entity: living room speaker
+            - Would you turn on  living room speaker  please?:
+                    - entity: living room speaker
+            - I'd like to turn  my living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn  my living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn  the living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn  the living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn   living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn   living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn on my living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn on my living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn on the living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn on the living room speaker:
+                    - entity: living room speaker
+            - I'd like to turn on  living room speaker on:
+                    - entity: living room speaker
+            - I'd like to turn on  living room speaker:
+                    - entity: living room speaker
+            - I would like  living room speaker on:
+                    - entity: living room speaker
+            - I would like the living room speaker on:
+                    - entity: living room speaker
+            - I would like my living room speaker on:
+                    - entity: living room speaker
+      assist.intent:
+            - tell home assistant to turn on the roomba:
+                    - command: turn on the roomba
+            - tell home assistant turn on the roomba:
+                    - command: turn on the roomba
 
 unmatched intents:
-  en-us:
-    - set a reminder to change my oil at 4 PM
+      en-us:
+            - set a reminder to change my oil at 4 PM

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -1227,16 +1227,16 @@ en-us:
               - entity: bedside lamp
 
     lights.set.color.intent:
-        - set  bedside lamp color to blue:
+        - adjust bedside lamp color to blue:
               - entity: bedside lamp
               - color: blue
-        - set the bedside lamp color to blue:
+        - adjust the bedside lamp color to blue:
               - entity: bedside lamp
               - color: blue
-        - set my bedside lamp color to blue:
+        - adjust my bedside lamp color to blue:
               - entity: bedside lamp
               - color: blue
-        - make  bedside lamp color to blue:
+        - make bedside lamp color to blue:
               - entity: bedside lamp
               - color: blue
         - make the bedside lamp color to blue:
@@ -1251,16 +1251,16 @@ en-us:
         - make the light bedside lamp to blue:
               - entity: bedside lamp
               - color: blue
-        - make  light bedside lamp to blue:
+        - make light bedside lamp to blue:
               - entity: bedside lamp
               - color: blue
-        - set my light bedside lamp to blue:
+        - change my light bedside lamp to blue:
               - entity: bedside lamp
               - color: blue
-        - set the light bedside lamp to blue:
+        - change the light bedside lamp to blue:
               - entity: bedside lamp
               - color: blue
-        - set  light bedside lamp to blue:
+        - change light bedside lamp to blue:
               - entity: bedside lamp
               - color: blue
 
@@ -1473,3 +1473,13 @@ en-us:
               - entity: living room speaker
         - I would like my living room speaker on:
               - entity: living room speaker
+    assist.intent:
+        - tell home assistant to turn on the roomba
+              - command: turn on the roomba
+        - tell home assistant turn on the roomba
+              - command: turn on the roomba
+
+
+unmatched intents:
+  en-us:
+    - set a reminder to change my oil at 4 PM

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -39,5 +39,6 @@ intents:
     - sensor.intent
     - lights.increase.brightness.intent
     - show.area.dashboard.intent
+    - assist.intent
   # Adapt intents are the name passed to the constructor
   adapt: []


### PR DESCRIPTION
# Description
fix: loosen "set" intents so it won't conflict with other skills
feat: emit event for passing intents to Home Assistant Assist endpoint (functionally won't do anything unless we add the feature from https://github.com/OpenVoiceOS/ovos-PHAL-plugin-homeassistant/issues/12)
docs: update README with more current information on setting up the skill, including the fact that recent versions of Neon come with the skill and affiliated PHAL plugin pre-bundled

Tested on a containerized Neon setup in Ubuntu, works as expected

# Issues
Closes #15
Closes #16